### PR TITLE
Fix specbomb desynching Saturn users

### DIFF
--- a/src/lua_playerlib.c
+++ b/src/lua_playerlib.c
@@ -139,7 +139,7 @@ static const udata_field_t player_fields[] = {
     FIELD(player_t, awayviewmobj,     udatalib_getter_mobj,        player_awayviewmobj_setter),
     FIELD(player_t, awayviewtics,     udatalib_getter_int32,       player_awayviewtics_setter),
     FIELD(player_t, awayviewaiming,   udatalib_getter_angle,       udatalib_setter_angle),
-    FIELD(player_t, spectator,        udatalib_getter_boolean,     udatalib_setter_boolean),
+    FIELD(player_t, spectator,        udatalib_getter_boolean,     udatalib_setter_boolean_nocheck), // ffs
     FIELD(player_t, bot,              udatalib_getter_uint8,       player_bot_noset),
     FIELD(player_t, jointime,         udatalib_getter_tic,         udatalib_setter_tic),
     FIELD(player_t, spectatorreentry, udatalib_getter_tic,         udatalib_setter_tic),

--- a/src/lua_udatalib.c
+++ b/src/lua_udatalib.c
@@ -82,6 +82,10 @@ UDATALIB_SIMPLE_SETTER(const char*, luaL_checkstring)
 int udatalib_setter_boolean(lua_State *L)
 UDATALIB_SIMPLE_SETTER(boolean, luaL_checkboolean)
 
+// ffs
+int udatalib_setter_boolean_nocheck(lua_State *L)
+UDATALIB_SIMPLE_SETTER(boolean, lua_toboolean)
+
 int udatalib_setter_spritenum(lua_State *L)
 UDATALIB_SIMPLE_SETTER(spritenum_t, (spritenum_t)luaL_checkinteger)
 

--- a/src/lua_udatalib.h
+++ b/src/lua_udatalib.h
@@ -62,6 +62,7 @@ int udatalib_setter_uint64(lua_State *L);
 int udatalib_setter_int64(lua_State *L);
 int udatalib_setter_string(lua_State *L);
 int udatalib_setter_boolean(lua_State *L);
+int udatalib_setter_boolean_nocheck(lua_State *L);
 int udatalib_setter_spritenum(lua_State *L);
 int udatalib_setter_mobj(lua_State *L);
 int udatalib_setter_playerstate(lua_State *L);


### PR DESCRIPTION
Original setter for `player.spectator` was using `lua_toboolean`, which allows conversion from any other type (such as numbers). Meanwhile setter in Saturn was using `luaL_checkboolean`, which throws an error when argument is not boolean. Weird that some parts of code use checkboolean, and some toboolean, but oh well