### PR TITLE
Refactor hwr drawnodes

### DIFF
--- a/src/hardware/hw_glob.h
+++ b/src/hardware/hw_glob.h
@@ -80,4 +80,14 @@ extern consvar_t cv_grrounddown; // on/off
 extern INT32 patchformat;
 extern INT32 textureformat;
 
+// --------
+// hw_main.c  // originally hw_drawnodes.c from HWPortal branch
+// --------
+void HWR_AddTransparentWall(FOutVector *wallVerts, FSurfaceInfo *pSurf, INT32 texnum, FBITFIELD blend, boolean fogwall, INT32 lightlevel, extracolormap_t *wallcolormap);
+void HWR_AddTransparentFloor(lumpnum_t lumpnum, extrasubsector_t *xsub, boolean isceiling, fixed_t fixedheight, INT32 lightlevel, INT32 alpha, sector_t *FOFSector, FBITFIELD blend, boolean fogplane, extracolormap_t *planecolormap);
+void HWR_AddTransparentPolyobjectFloor(lumpnum_t lumpnum, polyobj_t *polysector, boolean isceiling, fixed_t fixedheight,
+                             INT32 lightlevel, INT32 alpha, sector_t *FOFSector, FBITFIELD blend, extracolormap_t *planecolormap);
+
+void HWR_RenderDrawNodes(void);
+
 #endif //_HW_GLOB_


### PR DESCRIPTION
This seems to fix the rare "diff is zero" crash on certain maps with visportals in ogl

og: Use single dynamic array instead of three for storing drawnodes Remove now unnecessary drawcount variable