### PR TITLE
Toggable Lap Emblem Animation

### DIFF
--- a/src/d_netcmd.c
+++ b/src/d_netcmd.c
@@ -466,6 +466,8 @@ consvar_t cv_showping = {"showping", "Always", CV_SAVE, showping_cons_t, NULL, 0
 static CV_PossibleValue_t pingmeasurement_cons_t[] = {{0, "Frames"}, {1, "Milliseconds"}, {0, NULL}};
 consvar_t cv_pingmeasurement = {"pingmeasurement", "Frames", CV_SAVE, pingmeasurement_cons_t, NULL, 0, NULL, NULL, 0, 0, NULL};
 
+consvar_t cv_showlapemblem = {"showlapemblem", "On", CV_SAVE, CV_OnOff, NULL, 0, NULL, NULL, 0, 0, NULL};
+
 consvar_t cv_showviewpointtext = {"showviewpointtext", "On", CV_SAVE, CV_OnOff, 0, 0, NULL, NULL, 0, 0, NULL};
 
 // Intermission time Tails 04-19-2002
@@ -765,6 +767,8 @@ void D_RegisterServerCommands(void)
 	CV_RegisterVar(&cv_pingtimeout);
 	CV_RegisterVar(&cv_showping);
 	CV_RegisterVar(&cv_pingmeasurement);
+	
+	CV_RegisterVar(&cv_showlapemblem);
 
 	CV_RegisterVar(&cv_showtrackaddon);
 

--- a/src/d_netcmd.h
+++ b/src/d_netcmd.h
@@ -150,6 +150,8 @@ extern consvar_t cv_pingtimeout;
 extern consvar_t cv_showping;
 extern consvar_t cv_pingmeasurement;
 
+extern consvar_t cv_showlapemblem; 
+
 extern consvar_t cv_showviewpointtext;
 
 extern consvar_t cv_skipmapcheck;

--- a/src/k_kart.c
+++ b/src/k_kart.c
@@ -9112,6 +9112,9 @@ static void K_drawChallengerScreen(void)
 
 static void K_drawLapStartAnim(void)
 {
+	if (! cv_showlapemblem.value)
+		return;
+	
 	// This is an EVEN MORE insanely complicated animation.
 	const UINT8 progress = 80-stplyr->kartstuff[k_lapanimation];
 	UINT8 *colormap = R_GetTranslationColormap(TC_DEFAULT, stplyr->skincolor, GTC_CACHE);

--- a/src/m_menu.c
+++ b/src/m_menu.c
@@ -1697,6 +1697,7 @@ static menuitem_t OP_SaturnMenu[] =
 	{IT_STRING | IT_CVAR, NULL, "Serverqueue waittime", 	&cv_connectawaittime, 	 30},
 	//{IT_STRING | IT_CVAR, NULL, "Addon Download Speed", 	&cv_downloadspeed, 		 55},	//no idea why you would wanna change it anyways
 	{IT_STRING | IT_CVAR, NULL, "Skin Select Spinning Speed",		 	&cv_skinselectspin, 	 50},
+	{IT_STRING | IT_CVAR, NULL, "Show Lap Emblem",		 	&cv_showlapemblem, 	 60},
 	{IT_STRING | IT_CVAR, NULL, "No Midnight Channel Flicker", 	&cv_lessflicker, 		 75},
 	{IT_SUBMENU|IT_STRING,	NULL,	"Player distortion...", &OP_PlayerDistortDef,	 100},
 	{IT_SUBMENU|IT_STRING,	NULL,	"Hud Offsets...", 		&OP_HudOffsetDef,		 115},


### PR DESCRIPTION
hides the animation that happens when you do a lap toggable with "showlapemblem" and in saturn options