### PR TITLE
Return null in S_FindMusicCredit if there are no musicdefs at all 

### DIFF
--- a/src/s_sound.c
+++ b/src/s_sound.c
@@ -1527,7 +1527,7 @@ musicdef_t *S_FindMusicCredit(const char *musname)
 	musicdef_t *def = musicdefstart;
 
 	if (!def) // No definitions
-		return;
+		return NULL;
 
 	while (def)
 	{


### PR DESCRIPTION
Thanks NepDisk for pointing at that