### PR TITLE
`P_FlashPal` support in palette renderering

### DIFF
--- a/src/hardware/hw_cache.c
+++ b/src/hardware/hw_cache.c
@@ -576,7 +576,6 @@ void HWR_SetPalette(RGBA_t *palette)
 		Z_FreeTags(PU_HWRCACHE_UNLOCKED, PU_HWRCACHE_UNLOCKED);
 	}
 }
-
 // --------------------------------------------------------------------------
 // Make sure texture is downloaded and set it as the source
 // --------------------------------------------------------------------------

--- a/src/hardware/hw_main.c
+++ b/src/hardware/hw_main.c
@@ -151,8 +151,7 @@ static void CV_grpaletteshader_OnChange(void)
 	{
 		HWD.pfnSetSpecialState(HWD_SET_PALETTE_SHADER_ENABLED, cv_grpaletteshader.value);
 		gr_use_palette_shader = cv_grpaletteshader.value;
-		//R_ClearColormaps();
-		InitPalette(0);
+		V_SetPalette(0);
 	}
 }
 

--- a/src/hardware/hw_main.c
+++ b/src/hardware/hw_main.c
@@ -152,7 +152,7 @@ static void CV_grpaletteshader_OnChange(void)
 		HWD.pfnSetSpecialState(HWD_SET_PALETTE_SHADER_ENABLED, cv_grpaletteshader.value);
 		gr_use_palette_shader = cv_grpaletteshader.value;
 		//R_ClearColormaps();
-		InitPalette();
+		InitPalette(0);
 	}
 }
 
@@ -6156,8 +6156,6 @@ void HWR_RenderWall(FOutVector *wallVerts, FSurfaceInfo *pSurf, FBITFIELD blend,
 
 	pSurf->PolyColor.s.alpha = alpha; // put the alpha back after lighting
 
-	HWD.pfnSetShader(gr_use_palette_shader ? 10 : 2);	// wall shader
-
 	if (blend & PF_Environment)
 		blendmode |= PF_Occlude;	// PF_Occlude must be used for solid objects
 
@@ -6169,6 +6167,8 @@ void HWR_RenderWall(FOutVector *wallVerts, FSurfaceInfo *pSurf, FBITFIELD blend,
 
 	blendmode |= PF_Modulated;	// No PF_Occlude means overlapping (incorrect) transparency
 
+	if (!fogwall)
+		HWD.pfnSetShader(gr_use_palette_shader ? 10 : 2);	// wall shader
 	HWD.pfnDrawPolygon(pSurf, wallVerts, 4, blendmode, false);
 
 #ifdef WALLSPLATS
@@ -6200,7 +6200,7 @@ void HWR_DoPostProcessor(player_t *player)
 
 	// Armageddon Blast Flash!
 	// Could this even be considered postprocessor?
-	if (player->flashcount)
+	if (player->flashcount && !cv_grpaletteshader.value)
 	{
 		FOutVector      v[4];
 		FSurfaceInfo Surf;
@@ -6329,6 +6329,8 @@ void HWR_MakeScreenFinalTexture(void)
 
 void HWR_DrawScreenFinalTexture(int width, int height)
 {
+	if (gr_use_palette_shader)
+		HWD.pfnSetShader(11);	//post processing
     HWD.pfnDrawScreenFinalTexture(width, height);
 }
 

--- a/src/hardware/r_opengl/r_opengl.h
+++ b/src/hardware/r_opengl/r_opengl.h
@@ -135,6 +135,6 @@ typedef enum
 
 // in order for custom playpals n shit to work properly
 extern boolean gl_palette_initialized;
-void InitPalette(int flashnum);
+void InitPalette(int flashnum, boolean skiplut);
 
 #endif

--- a/src/hardware/r_opengl/r_opengl.h
+++ b/src/hardware/r_opengl/r_opengl.h
@@ -135,6 +135,6 @@ typedef enum
 
 // in order for custom playpals n shit to work properly
 extern boolean gl_palette_initialized;
-void InitPalette(void);
+void InitPalette(int flashnum);
 
 #endif

--- a/src/st_stuff.c
+++ b/src/st_stuff.c
@@ -232,18 +232,22 @@ void ST_doPaletteStuff(void)
 	else
 		palette = 0;
 
+	palette = min(max(palette, 0), 13);
+
 #ifdef HWRENDER
-	if (rendermode == render_opengl)
+	if (rendermode == render_opengl && !cv_grpaletteshader.value)
 		palette = 0; // No flashpals here in OpenGL
 #endif
-
-	palette = min(max(palette, 0), 13);
 
 	if (palette != st_palette)
 	{
 		st_palette = palette;
 
-		if (rendermode == render_soft)
+#ifdef HWRENDER
+		if (rendermode != render_none && cv_grpaletteshader.value)
+#else
+		if (rendermode != render_none)
+#endif
 		{
 			//V_SetPaletteLump(GetPalette()); // Reset the palette -- is this needed?
 			if (!splitscreen)
@@ -2163,13 +2167,7 @@ void ST_Drawer(void)
 		st_palette = -1;
 
 	// Do red-/gold-shifts from damage/items
-#ifdef HWRENDER
-	//25/08/99: Hurdler: palette changes is done for all players,
-	//                   not only player1! That's why this part
-	//                   of code is moved somewhere else.
-	if (rendermode == render_soft)
-#endif
-		if (rendermode != render_none) ST_doPaletteStuff();
+	if (rendermode != render_none) ST_doPaletteStuff();
 
 	if (st_overlay)
 	{

--- a/src/v_video.c
+++ b/src/v_video.c
@@ -226,12 +226,15 @@ void V_SetPalette(INT32 palettenum)
 
 #ifdef HWRENDER
 	if (rendermode != render_soft && rendermode != render_none) {
-		if (cv_grpaletteshader.value == 1){
+		// in palette rendering mode, we already manage our palette ourselves
+		if (cv_grpaletteshader.value == 1) 
+		{
 			// reset our palette lookups n shit
 			gl_palette_initialized = false;
-			InitPalette(palettenum);
+			InitPalette(palettenum, true);
 		}
-		HWR_SetPalette(&pLocalPalette[palettenum*256]);
+		else
+			HWR_SetPalette(pLocalPalette);
 	}		
 #if (defined (__unix__) && !defined (MSDOS)) || defined (UNIXCOMMON) || defined (HAVE_SDL)
 	else
@@ -246,12 +249,14 @@ void V_SetPaletteLump(const char *pal)
 	LoadPalette(pal);
 #ifdef HWRENDER
 	if (rendermode != render_soft && rendermode != render_none) {
-		if (cv_grpaletteshader.value == 1){
+		if (cv_grpaletteshader.value == 1) 
+		{
 			// reset our palette lookups n shit
 			gl_palette_initialized = false;
-			InitPalette(0);
+			InitPalette(0, false);
 		}
-		HWR_SetPalette(pLocalPalette);
+		else
+			HWR_SetPalette(pLocalPalette);
 	}
 #if (defined (__unix__) && !defined (MSDOS)) || defined (UNIXCOMMON) || defined (HAVE_SDL)
 	else

--- a/src/v_video.c
+++ b/src/v_video.c
@@ -226,11 +226,11 @@ void V_SetPalette(INT32 palettenum)
 
 #ifdef HWRENDER
 	if (rendermode != render_soft && rendermode != render_none) {
-		
 		if (cv_grpaletteshader.value == 1){
-		// reset our palette lookups n shit
-		gl_palette_initialized = false;
-		InitPalette();}
+			// reset our palette lookups n shit
+			gl_palette_initialized = false;
+			InitPalette(palettenum);
+		}
 		HWR_SetPalette(&pLocalPalette[palettenum*256]);
 	}		
 #if (defined (__unix__) && !defined (MSDOS)) || defined (UNIXCOMMON) || defined (HAVE_SDL)
@@ -247,9 +247,10 @@ void V_SetPaletteLump(const char *pal)
 #ifdef HWRENDER
 	if (rendermode != render_soft && rendermode != render_none) {
 		if (cv_grpaletteshader.value == 1){
-		// reset our palette lookups n shit
-		gl_palette_initialized = false;
-		InitPalette();}
+			// reset our palette lookups n shit
+			gl_palette_initialized = false;
+			InitPalette(0);
+		}
 		HWR_SetPalette(pLocalPalette);
 	}
 #if (defined (__unix__) && !defined (MSDOS)) || defined (UNIXCOMMON) || defined (HAVE_SDL)


### PR DESCRIPTION
Example with `PAL_NUKE`

![kart0004](https://github.com/Indev450/SRB2Kart-Saturn/assets/126386046/7c587a08-ab52-41a6-b289-45f082bfb531)

This also fixes gamma since gamma wasn't read during the init process. Whoops.