### PR TITLE
``v.getSpritePatch`` from 2.2

### DIFF
--- a/src/lua_hudlib.c
+++ b/src/lua_hudlib.c
@@ -409,12 +409,12 @@ static int libd_getSpritePatch(lua_State *L)
 	if ((i == SPR_PLAY) && (skn < 0))
 		return luaL_error(L, "You must provide a skin for player sprites!");
 
-	if (skn < 0)
+	if (skn < 0) // standard sprite
 	{
 		sprdef = &sprites[i];
 		sprinfo = &spriteinfo[i];
 	}
-	else
+	else // player skin
 	{
 		sprdef = &skins[skn].spritedef;
 		sprinfo = &skins[skn].sprinfo;


### PR DESCRIPTION
This adds [``getSpritePatch``](https://wiki.srb2.org/wiki/Lua/Functions#Patch/string_drawing_functions) to the BLUA HUD functions.
NOTE: The function is structured similarly to 2.2's ``getSprite2Patch`` function, and *not* the standard ``getSpritePatch`` function, due to the player-sprite handling:
``v.getSpritePatch(string/int skin, string/int sprite, [int frame, [int rotation, [angle_t rollangle]]])``

``getSpritePatch`` allows for advanced HUD capabilities by drawing object sprites on the HUD, allowing for the following features:
* Draw object sprites on the screen, with support for 8 angles. Good for stuff like lua menus.
* Draw *rotating* patches on the screen. Good for flashier HUD effects, or things like a dial speedometer.
  * NOTE: This is disabled if **Sprite Rotation** is turned off.

I've attached a test lua for this addition:
[bananatest.txt (save as a .lua file!)](https://github.com/Indev450/SRB2Kart-Saturn/files/13955127/bananatest.txt)

Should everything work fine, you should see two rotating sprites (a banana, and Tails with the default green) on the upper left corner of the screen:
* ![rotatinghudsprites](https://github.com/Indev450/SRB2Kart-Saturn/assets/110704015/d0274a7c-042c-4eda-a227-7d02ac1d9ed3)


