### PR TITLE
port R_PointToPseudoAngle for Opengl sector clipping from PrBoom+

### DIFF
--- a/src/hardware/hw_clip.c
+++ b/src/hardware/hw_clip.c
@@ -344,9 +344,9 @@ angle_t gld_FrustumAngle(angle_t tiltangle)
 	// ok, this is a gross hack that barely works...
 	// but at least it doesn't overestimate too much...
 	floatangle = 2.0f + (45.0f + (tilt / 1.9f)) * (float)render_fov * 48.0f / render_multiplier / 90.0f;
-	a1 = ANG1 * (int)floatangle;
-	if (a1 >= ANGLE_180)
+	if (floatangle >= ANGLE_180)
 		return 0xffffffff;
+	a1 = (angle_t)xs_CRoundToInt(ANG1 * floatangle);
 	return a1;
 }
 

--- a/src/hardware/hw_main.c
+++ b/src/hardware/hw_main.c
@@ -2859,8 +2859,8 @@ void HWR_AddLine(seg_t *line)
 	}
 
 	// OPTIMIZE: quickly reject orthogonal back sides.
-	angle1 = R_PointToAngle64(v1x, v1y);
-	angle2 = R_PointToAngle64(v2x, v2y);
+	angle1 = R_PointToPseudoAngle(v1x, v1y);
+	angle2 = R_PointToPseudoAngle(v2x, v2y);
 
 	// do an extra culling check when rendering portals
 	// check if any line vertex is on the viewable side of the portal target line
@@ -3053,8 +3053,8 @@ boolean HWR_CheckBBox(fixed_t *bspcoord)
 		if (mindist > current_bsp_culling_distance) return false;
 	}
 
-	angle1 = R_PointToAngle64(px1, py1);
-	angle2 = R_PointToAngle64(px2, py2);
+	angle1 = R_PointToPseudoAngle(px1, py1);
+	angle2 = R_PointToPseudoAngle(px2, py2);
 	return gld_clipper_SafeCheckRange(angle2, angle1);
 }
 
@@ -5913,8 +5913,8 @@ static void HWR_PortalClipping(gl_portal_t *portal)
 
 	line_t *line = &lines[portal->clipline];
 
-	angle1 = R_PointToAngleEx(viewx, viewy, line->v1->x, line->v1->y);
-	angle2 = R_PointToAngleEx(viewx, viewy, line->v2->x, line->v2->y);
+	angle1 = R_PointToPseudoAngle(line->v1->x, line->v1->y);
+	angle2 = R_PointToPseudoAngle(line->v2->x, line->v2->y);
 
 	// clip things that are not inside the portal window from our viewpoint
 	gld_clipper_SafeAddClipRange(angle2, angle1);

--- a/src/m_fixed.h
+++ b/src/m_fixed.h
@@ -265,6 +265,42 @@ typedef struct
 	fixed_t y;
 } vector2_t;
 
+
+// Source: "Know Your FPU: Fixing Floating Fast"
+//         http://www.stereopsis.com/sree/fpu2006.html
+//
+// xs_CRoundToInt:  Round toward nearest, but ties round toward even (just like FISTP)
+// taken from prboom+ for faster OpenGL culling / R_PointToPseudoAngle
+#ifndef _xs_DEFAULT_CONVERSION
+#define _xs_DEFAULT_CONVERSION      0
+#endif //_xs_DEFAULT_CONVERSION
+
+#ifdef WORDS_BIGENDIAN
+	#define _xs_iexp_				0
+	#define _xs_iman_				1
+#else
+	#define _xs_iexp_				1       //intel is little endian
+	#define _xs_iman_				0
+#endif //BigEndian_
+
+typedef double	real64;
+typedef union _xs_doubleints
+{
+	real64 val;
+	unsigned ival[2];
+} _xs_doubleints;
+
+FUNCMATH FUNCINLINE ATTRINLINE int xs_CRoundToInt(real64 val)
+{
+#if _xs_DEFAULT_CONVERSION==0
+	_xs_doubleints uval;
+	uval.val = val + 6755399441055744.0;
+	return uval.ival[_xs_iman_];
+#else
+    return int(floor(val+.5));
+#endif
+}
+
 vector2_t *FV2_Load(vector2_t *vec, fixed_t x, fixed_t y);
 vector2_t *FV2_UnLoad(vector2_t *vec, fixed_t *x, fixed_t *y);
 vector2_t *FV2_Copy(vector2_t *a_o, const vector2_t *a_i);

--- a/src/r_main.c
+++ b/src/r_main.c
@@ -475,7 +475,7 @@ angle_t R_PointToPseudoAngle(fixed_t x, fixed_t y)
 	}
 	else
 	{
-		double result = vecy / (vecx + vecy);
+		INT64 result = vecy / (vecx + vecy);
 		if (vecx < 0)
 		{
 			result = 2.0 - result;

--- a/src/r_main.c
+++ b/src/r_main.c
@@ -466,17 +466,16 @@ angle_t R_PointToAngleEx(INT32 x2, INT32 y2, INT32 x1, INT32 y1)
 angle_t R_PointToPseudoAngle(fixed_t x, fixed_t y)
 {
 	// Note: float won't work here as it's less precise than the BAM values being passed as parameters
-	double vecx = (double)x - viewx;
-	double vecy = (double)y - viewy;
-	double epsilon = 1e-9;
+	INT64 vecx = x - viewx;
+	INT64 vecy = y - viewy;
 
-	if (fabs(vecx) < epsilon && fabs(vecy) < epsilon)
+	if (vecx == 0 && vecy == 0)
 	{
 		return 0;
 	}
 	else
 	{
-		double result = vecy / (fabs(vecx) + fabs(vecy));
+		INT64 result = vecy / (vecx + vecy);
 		if (vecx < 0)
 		{
 			result = 2.0 - result;

--- a/src/r_main.c
+++ b/src/r_main.c
@@ -475,7 +475,7 @@ angle_t R_PointToPseudoAngle(fixed_t x, fixed_t y)
 	}
 	else
 	{
-		INT64 result = vecy / (vecx + vecy);
+		double result = vecy / (vecx + vecy);
 		if (vecx < 0)
 		{
 			result = 2.0 - result;

--- a/src/r_main.c
+++ b/src/r_main.c
@@ -465,23 +465,24 @@ angle_t R_PointToAngleEx(INT32 x2, INT32 y2, INT32 x1, INT32 y1)
 
 angle_t R_PointToPseudoAngle(fixed_t x, fixed_t y)
 {
-  // Note: float won't work here as it's less precise than the BAM values being passed as parameters
-  double vecx = (double)x - viewx;
-  double vecy = (double)y - viewy;
+	// Note: float won't work here as it's less precise than the BAM values being passed as parameters
+	double vecx = (double)x - viewx;
+	double vecy = (double)y - viewy;
+	double epsilon = 1e-9;
 
-  if (vecx == 0 && vecy == 0)
-  {
-    return 0;
-  }
-  else
-  {
-    double result = vecy / (fabs(vecx) + fabs(vecy));
-    if (vecx < 0)
-    {
-      result = 2.0 - result;
-    }
-    return (angle_t)xs_CRoundToInt(result * (1 << 30));
-  }
+	if (fabs(vecx) < epsilon && fabs(vecy) < epsilon)
+	{
+		return 0;
+	}
+	else
+	{
+		double result = vecy / (fabs(vecx) + fabs(vecy));
+		if (vecx < 0)
+		{
+			result = 2.0 - result;
+		}
+		return (angle_t)xs_CRoundToInt(result * (1 << 30));
+	}
 }
 
 fixed_t R_PointToDist2(fixed_t px2, fixed_t py2, fixed_t px1, fixed_t py1)

--- a/src/r_main.c
+++ b/src/r_main.c
@@ -466,16 +466,17 @@ angle_t R_PointToAngleEx(INT32 x2, INT32 y2, INT32 x1, INT32 y1)
 angle_t R_PointToPseudoAngle(fixed_t x, fixed_t y)
 {
 	// Note: float won't work here as it's less precise than the BAM values being passed as parameters
-	INT64 vecx = x - viewx;
-	INT64 vecy = y - viewy;
+	double vecx = (double)x - viewx;
+	double vecy = (double)y - viewy;
+	double epsilon = 1e-9;
 
-	if (vecx == 0 && vecy == 0)
+	if (fabs(vecx) < epsilon && fabs(vecy) < epsilon)
 	{
 		return 0;
 	}
 	else
 	{
-		INT64 result = vecy / (vecx + vecy);
+		double result = vecy / (fabs(vecx) + fabs(vecy));
 		if (vecx < 0)
 		{
 			result = 2.0 - result;

--- a/src/r_main.h
+++ b/src/r_main.h
@@ -71,7 +71,7 @@ angle_t R_PointToAngle(fixed_t x, fixed_t y);
 angle_t R_PointToAngle64(INT64 x, INT64 y);
 angle_t R_PointToAngle2(fixed_t px2, fixed_t py2, fixed_t px1, fixed_t py1);
 angle_t R_PointToAngleEx(INT32 x2, INT32 y2, INT32 x1, INT32 y1);
-angle_t R_PointToPseudoAngle(fixed_t x, fixed_t y)
+angle_t R_PointToPseudoAngle(fixed_t x, fixed_t y);
 fixed_t R_PointToDist(fixed_t x, fixed_t y);
 fixed_t R_PointToDist2(fixed_t px2, fixed_t py2, fixed_t px1, fixed_t py1);
 angle_t R_PlayerSliptideAngle(player_t *player);

--- a/src/r_main.h
+++ b/src/r_main.h
@@ -71,6 +71,7 @@ angle_t R_PointToAngle(fixed_t x, fixed_t y);
 angle_t R_PointToAngle64(INT64 x, INT64 y);
 angle_t R_PointToAngle2(fixed_t px2, fixed_t py2, fixed_t px1, fixed_t py1);
 angle_t R_PointToAngleEx(INT32 x2, INT32 y2, INT32 x1, INT32 y1);
+angle_t R_PointToPseudoAngle(fixed_t x, fixed_t y)
 fixed_t R_PointToDist(fixed_t x, fixed_t y);
 fixed_t R_PointToDist2(fixed_t px2, fixed_t py2, fixed_t px1, fixed_t py1);
 angle_t R_PlayerSliptideAngle(player_t *player);


### PR DESCRIPTION
this should speed up opengl sector clipping a bit
didnt notice any negative side effects or rendering issues at all but gave me a slight performance boost on certain maps that suffer from view distance related performance issue
Note: Software renderer wont use this as it kinda needs more precision/ somewhat exact angles or else itll break

> R_PointToPseudoAngle
>  Returns the pseudoangle between the line p1 to (infinity, p1.y) and the
> line from p1 to p2. The pseudoangle has the property that the ordering of
> points by true angle anround p1 and ordering of points by pseudoangle are the
> same.
> 
> For clipping exact angles are not needed. Only the ordering matters.
> This is about as fast as the fixed point R_PointToAngle2 but without
> the precision issues associated with that function.