### PR TITLE
Fix master server thread segfaulting on startup

### DIFF
--- a/src/d_netcmd.c
+++ b/src/d_netcmd.c
@@ -35,7 +35,6 @@
 #include "p_spec.h"
 #include "m_cheat.h"
 #include "d_clisrv.h"
-#include "v_video.h"
 #include "d_main.h"
 #include "m_random.h"
 #include "f_finale.h"
@@ -955,31 +954,6 @@ void D_RegisterClientCommands(void)
 	CV_RegisterVar(&cv_amigatype);
 #endif
 #endif
-
-	// FIXME: not to be here.. but needs be done for config loading
-	CV_RegisterVar(&cv_globalgamma);
-	CV_RegisterVar(&cv_globalsaturation);
-
-	CV_RegisterVar(&cv_rhue);
-	CV_RegisterVar(&cv_yhue);
-	CV_RegisterVar(&cv_ghue);
-	CV_RegisterVar(&cv_chue);
-	CV_RegisterVar(&cv_bhue);
-	CV_RegisterVar(&cv_mhue);
-
-	CV_RegisterVar(&cv_rgamma);
-	CV_RegisterVar(&cv_ygamma);
-	CV_RegisterVar(&cv_ggamma);
-	CV_RegisterVar(&cv_cgamma);
-	CV_RegisterVar(&cv_bgamma);
-	CV_RegisterVar(&cv_mgamma);
-
-	CV_RegisterVar(&cv_rsaturation);
-	CV_RegisterVar(&cv_ysaturation);
-	CV_RegisterVar(&cv_gsaturation);
-	CV_RegisterVar(&cv_csaturation);
-	CV_RegisterVar(&cv_bsaturation);
-	CV_RegisterVar(&cv_msaturation);
 
 	// m_menu.c
 	//CV_RegisterVar(&cv_compactscoreboard);

--- a/src/http-mserv.c
+++ b/src/http-mserv.c
@@ -544,6 +544,8 @@ HMS_fetch_rules (char *buffer, size_t buffer_size)
 		else
 			buffer = NULL;
 	}
+	else
+		buffer = NULL;
 
 	HMS_end(hms);
 

--- a/src/screen.c
+++ b/src/screen.c
@@ -233,6 +233,30 @@ void SCR_Startup(void)
 	CV_RegisterVar(&cv_menucaps);
 	CV_RegisterVar(&cv_constextsize);
 
+	CV_RegisterVar(&cv_globalgamma);
+	CV_RegisterVar(&cv_globalsaturation);
+
+	CV_RegisterVar(&cv_rhue);
+	CV_RegisterVar(&cv_yhue);
+	CV_RegisterVar(&cv_ghue);
+	CV_RegisterVar(&cv_chue);
+	CV_RegisterVar(&cv_bhue);
+	CV_RegisterVar(&cv_mhue);
+
+	CV_RegisterVar(&cv_rgamma);
+	CV_RegisterVar(&cv_ygamma);
+	CV_RegisterVar(&cv_ggamma);
+	CV_RegisterVar(&cv_cgamma);
+	CV_RegisterVar(&cv_bgamma);
+	CV_RegisterVar(&cv_mgamma);
+
+	CV_RegisterVar(&cv_rsaturation);
+	CV_RegisterVar(&cv_ysaturation);
+	CV_RegisterVar(&cv_gsaturation);
+	CV_RegisterVar(&cv_csaturation);
+	CV_RegisterVar(&cv_bsaturation);
+	CV_RegisterVar(&cv_msaturation);
+
 	V_SetPalette(0);
 }
 


### PR DESCRIPTION
I've finally figured out why the master server thread segfaults if you start the game without an internet connection on OpenGL!

In ``D_RegisterServerCommands``, the main thread registers ``cv_masterserver``, which starts the ``change-masterserver`` thread. Then, the main thread calls ``D_RegisterClientCommands``, which registers a series of 20 cvars (starting with ``cv_globalgamma``), all of which call ``V_SetPalette`` when initialized. At the same time, the MS thread might fail and print an error to the console. If there's no connection, it fails immediately.

At this point, a conflict occurs as the MS thread tries drawing patches while the main thread is flushing the cache; the patch in use by the MS thread is suddenly freed, triggering the segfault.

My solution? Move those 20 cvars to ``SCR_Startup``, which runs before ``D_RegisterServerCommands``.

Also, while researching, I found and fixed a bug in ``HMS_set_rules`` which made it accidentally return its (uninitialized) buffer if ``HMS_do`` fails.