### PR TITLE
Add Lua functions for HUD customization

### DIFF
--- a/LUASTUFF.md
+++ b/LUASTUFF.md
@@ -25,8 +25,8 @@ exist.
 
 ## x, y = hud.getOffsets(item)
 
-Returns the values of the given HUD item's `xoffset`/`yoffset` cvars, or nil if unsupported.
-Uses the same strings as `hud.enabled`.
+Returns the values of the given HUD item's `xoffset`/`yoffset` cvars.
+Available for any HUD item with offset cvars.
 
 ## x, y, flags = v.getDrawInfo(item)
 

--- a/LUASTUFF.md
+++ b/LUASTUFF.md
@@ -33,18 +33,16 @@ Uses the same strings as `hud.enabled`.
 Returns the X, Y and flags where the given HUD item will be drawn for the current displayplayer.
 Available for `item`, `gametypeinfo` and `minimap`.
 
-## v.drawItemBox(x, y, flags, small, dark, colormap)
+## patch, colormap = v.getColorHudPatch(item)
 
-Draws an item box at the given coordinates.
-`small`: true to draw small item box, false to draw large item box.
-`dark`: true if item box should be darkened.
-`colormap`: Colormap to draw the item box with. If nil, use displayplayer's HUD colormap.
-
-## v.drawItemMul(x, y, flags, small, colormap)
-
-Draws a multi-item sticker at the given coordinates.
-`small`: true to draw small sticker, false to draw large sticker.
-`colormap`: Colormap to draw the sticker with. If nil, use displayplayer's HUD colormap.
+Returns the patch and colormap to use for the given HUD item. Colorization is based on the user's settings.
+Available for `item` and `itemmul`.
+Extra arguments for some items:
+### item
+* `small`: true for small item box, false for big item box.
+* `dark`: true to darken item box. Depends on `darkitembox`.
+### itemmul
+* `small`: true for small sticker, false for big sticker.
 
 ## hudcolor = v.getHudColor()
 

--- a/LUASTUFF.md
+++ b/LUASTUFF.md
@@ -2,7 +2,7 @@
 
 ## mobj.localskin and player.localskin fields
 
-Allow reading and assigning localskins to players. Local skins for other objects aren't supported currently.
+Allow reading and assigning localskins.
 
 ## mobj.rollsum field
 
@@ -20,8 +20,39 @@ Changes vote background texture prefix (game looks for PREFIX + "W" or "C" (depe
 ## hud.add(fn, "vote") and hud.add(fn, "intermission")
 
 Hud hooks for vote screen and intermission screen. They only get drawer (`v`) as argument.
-To check if those hooks are available, check if globals FEATURE\_VOTEHUD and FEATURE\_INERMISSIONHUD
+To check if those hooks are available, check if globals FEATURE\_VOTEHUD and FEATURE\_INTERMISSIONHUD
 exist.
+
+## x, y = hud.getOffsets(item)
+
+Returns the values of the given HUD item's `xoffset`/`yoffset` cvars, or nil if unsupported.
+Uses the same strings as `hud.enabled`.
+
+## x, y, flags = v.getDrawInfo(item)
+
+Returns the X, Y and flags where the given HUD item will be drawn for the current displayplayer.
+Available for `item`, `gametypeinfo` and `minimap`.
+
+## v.drawItemBox(x, y, flags, small, dark, colormap)
+
+Draws an item box at the given coordinates.
+`small`: true to draw small item box, false to draw large item box.
+`dark`: true if item box should be darkened.
+`colormap`: Colormap to draw the item box with. If nil, use displayplayer's HUD colormap.
+
+## v.drawItemMul(x, y, flags, small, colormap)
+
+Draws a multi-item sticker at the given coordinates.
+`small`: true to draw small sticker, false to draw large sticker.
+`colormap`: Colormap to draw the sticker with. If nil, use displayplayer's HUD colormap.
+
+## hudcolor = v.getHudColor()
+
+Returns the displayplayer's HUD color.
+
+## colorize = v.useColorHud()
+
+Returns true if colorization is enabled, false otherwise.
 
 ## mobj.spritexscale, mobj.spriteyscale, mobj.spritexoffset, mobj.spriteyoffset, mobj.rollangle, mobj.sloperoll, mobj.rollmodel fields
 

--- a/src/hardware/hw_draw.c
+++ b/src/hardware/hw_draw.c
@@ -234,7 +234,7 @@ void HWR_DrawStretchyFixedPatch(GLPatch_t *gpatch, fixed_t x, fixed_t y, fixed_t
 			}
 			if (fabsf((float)vid.height - (float)BASEVIDHEIGHT * dupy) > 1.0E-36f)
 			{
-				if ((option & (V_SPLITSCREEN|V_SNAPTOBOTTOM)) == (V_SPLITSCREEN|V_SNAPTOBOTTOM))
+				if ((option & (V_SPLITSCREEN|V_SNAPTOTOP)) == (V_SPLITSCREEN|V_SNAPTOTOP))
 					cy += ((float)vid.height/2 - ((float)BASEVIDHEIGHT/2 * dupy));
 				else if (option & V_SNAPTOBOTTOM)
 					cy += ((float)vid.height - ((float)BASEVIDHEIGHT * dupy));
@@ -385,7 +385,7 @@ void HWR_DrawCroppedPatch(GLPatch_t *gpatch, fixed_t x, fixed_t y, fixed_t pscal
 			}
 			if (fabsf((float)vid.height - (float)BASEVIDHEIGHT * dupy) > 1.0E-36f)
 			{
-				if ((option & (V_SPLITSCREEN|V_SNAPTOBOTTOM)) == (V_SPLITSCREEN|V_SNAPTOBOTTOM))
+				if ((option & (V_SPLITSCREEN|V_SNAPTOTOP)) == (V_SPLITSCREEN|V_SNAPTOTOP))
 					cy += ((float)vid.height/2 - ((float)BASEVIDHEIGHT/2 * dupy));
 				else if (option & V_SNAPTOBOTTOM)
 					cy += ((float)vid.height - ((float)BASEVIDHEIGHT * dupy));

--- a/src/k_kart.c
+++ b/src/k_kart.c
@@ -7567,10 +7567,9 @@ INT32 K_calcSplitFlags(INT32 snapflags)
 	return (splitflags|snapflags);
 }
 
-drawinfo_t K_getItemBoxDrawinfo(void)
+void K_getItemBoxDrawinfo(drawinfo_t *out)
 {
 	INT32 fx, fy, fflags;
-	drawinfo_t info;
 
 	// pain and suffering defined below
 	if (splitscreen < 2) // don't change shit for THIS splitscreen.
@@ -7595,16 +7594,14 @@ drawinfo_t K_getItemBoxDrawinfo(void)
 		}
 	}
 
-	info.x = fx;
-	info.y = fy;
-	info.flags = fflags;
-	return info;
+	out->x = fx;
+	out->y = fy;
+	out->flags = fflags;
 }
 
-drawinfo_t K_getLapsDrawinfo(void)
+void K_getLapsDrawinfo(drawinfo_t *out)
 {
 	INT32 fx, fy, fflags;
-	drawinfo_t info;
 
 	// pain and suffering defined below
 	if (splitscreen < 2)	// don't change shit for THIS splitscreen.
@@ -7629,21 +7626,18 @@ drawinfo_t K_getLapsDrawinfo(void)
 		}
 	}
 
-	info.x = fx;
-	info.y = fy;
-	info.flags = fflags;
-	return info;
+	out->x = fx;
+	out->y = fy;
+	out->flags = fflags;
 }
 
-drawinfo_t K_getMinimapDrawinfo(void)
+void K_getMinimapDrawinfo(drawinfo_t *out)
 {
 	INT32 fx = MINI_X, fy = MINI_Y, fflags = (splitscreen == 3 ? 0 : V_SNAPTORIGHT);	// flags should only be 0 when it's centered (4p split)
-	drawinfo_t info;
 
-	info.x = fx;
-	info.y = fy;
-	info.flags = fflags;
-	return info;
+	out->x = fx;
+	out->y = fy;
+	out->flags = fflags;
 }
 
 patch_t *K_getItemBoxPatch(boolean small, boolean dark)
@@ -8018,7 +8012,8 @@ static void K_drawKartItem(void)
 	}
 
 	localbg = K_getItemBoxPatch((boolean)offset, dark);
-	drawinfo_t info = K_getItemBoxDrawinfo();
+	drawinfo_t info;
+	K_getItemBoxDrawinfo(&info);
 	fx = info.x;
 	fy = info.y;
 	fflags = info.flags;
@@ -8642,7 +8637,8 @@ static void K_drawKartLaps(void)
 	boolean flipstring = splitscreen > 1 && stplyrnum & 1;  // used for 3p or 4p
 	INT32 stringw = 0;	// used with the above
 
-	drawinfo_t info = K_getLapsDrawinfo();
+	drawinfo_t info;
+	K_getLapsDrawinfo(&info);
 	fx = info.x;
 	fy = info.y;
 	fflags = info.flags;
@@ -8845,7 +8841,8 @@ static void K_drawKartBumpersOrKarma(void)
 	boolean flipstring = splitscreen > 1 && stplyrnum & 1;  // same as laps, used for splitscreen
 	INT32 stringw = 0;	// used with the above
 
-	drawinfo_t info = K_getLapsDrawinfo();
+	drawinfo_t info;
+	K_getLapsDrawinfo(&info);
 	fx = info.x;
 	fy = info.y;
 	fflags = info.flags;
@@ -9171,7 +9168,8 @@ static void K_drawKartMinimap(void)
 	else
 		return; // no pic, just get outta here
 
-	drawinfo_t info = K_getMinimapDrawinfo();
+	drawinfo_t info;
+	K_getMinimapDrawinfo(&info);
 	x = info.x - (AutomapPic->width/2);
 	y = info.y - (AutomapPic->height/2);
 	splitflags = info.flags;

--- a/src/k_kart.c
+++ b/src/k_kart.c
@@ -7500,7 +7500,7 @@ static void K_initKartHUD(void)
 			ITEM2_X = BASEVIDWIDTH-39 + cv_item_xoffset.value;
 			ITEM2_Y = -8 + cv_item_yoffset.value;
 
-			LAPS2_X = BASEVIDWIDTH-40 + cv_laps_xoffset.value;
+			LAPS2_X = BASEVIDWIDTH-3 + cv_laps_xoffset.value;
 			LAPS2_Y = (BASEVIDHEIGHT/2)-13 + cv_laps_yoffset.value;
 
 			POSI2_X = BASEVIDWIDTH -4 + cv_posi_xoffset.value;
@@ -7565,6 +7565,97 @@ INT32 K_calcSplitFlags(INT32 snapflags)
 	}
 
 	return (splitflags|snapflags);
+}
+
+drawinfo_t K_getItemBoxDrawinfo(void)
+{
+	INT32 fx, fy, fflags;
+	drawinfo_t info;
+
+	// pain and suffering defined below
+	if (splitscreen < 2) // don't change shit for THIS splitscreen.
+	{
+		fx = ITEM_X;
+		fy = ITEM_Y;
+		fflags = K_calcSplitFlags(V_SNAPTOTOP|V_SNAPTOLEFT);
+	}
+	else // now we're having a fun game.
+	{
+		if (!(stplyrnum & 1)) // If we are P1 or P3...
+		{
+			fx = ITEM_X;
+			fy = ITEM_Y;
+			fflags = V_SNAPTOLEFT|(stplyrnum & 2 ? V_SPLITSCREEN : V_SNAPTOTOP); // flip P3 to the bottom.
+		}
+		else // else, that means we're P2 or P4.
+		{
+			fx = ITEM2_X;
+			fy = ITEM2_Y;
+			fflags = V_SNAPTORIGHT|(stplyrnum & 2 ? V_SPLITSCREEN : V_SNAPTOTOP); // flip P4 to the bottom
+		}
+	}
+
+	info.x = fx;
+	info.y = fy;
+	info.flags = fflags;
+	return info;
+}
+
+drawinfo_t K_getLapsDrawinfo(void)
+{
+	INT32 fx, fy, fflags;
+	drawinfo_t info;
+
+	// pain and suffering defined below
+	if (splitscreen < 2)	// don't change shit for THIS splitscreen.
+	{
+		fx = LAPS_X;
+		fy = LAPS_Y;
+		fflags = K_calcSplitFlags(V_SNAPTOBOTTOM|V_SNAPTOLEFT);
+	}
+	else
+	{
+		if (!(stplyrnum & 1))	// If we are P1 or P3...
+		{
+			fx = LAPS_X;
+			fy = LAPS_Y;
+			fflags = V_SNAPTOLEFT|(stplyrnum & 2 ? V_SPLITSCREEN|V_SNAPTOBOTTOM : 0);	// flip P3 to the bottom.
+		}
+		else // else, that means we're P2 or P4.
+		{
+			fx = LAPS2_X;
+			fy = LAPS2_Y;
+			fflags = V_SNAPTORIGHT|(stplyrnum & 2 ? V_SPLITSCREEN|V_SNAPTOBOTTOM : 0);	// flip P4 to the bottom
+		}
+	}
+
+	info.x = fx;
+	info.y = fy;
+	info.flags = fflags;
+	return info;
+}
+
+drawinfo_t K_getMinimapDrawinfo(void)
+{
+	INT32 fx = MINI_X, fy = MINI_Y, fflags = (splitscreen == 3 ? 0 : V_SNAPTORIGHT);	// flags should only be 0 when it's centered (4p split)
+	drawinfo_t info;
+
+	info.x = fx;
+	info.y = fy;
+	info.flags = fflags;
+	return info;
+}
+
+patch_t *K_getItemBoxPatch(boolean small, boolean dark)
+{
+	UINT8 ofs = (cv_darkitembox.value && dark ? 1 : 0) + (small ? 2 : 0);
+	return (cv_colorizeditembox.value && K_UseColorHud()) ? kp_itembgclr[ofs] : kp_itembg[ofs];
+}
+
+patch_t *K_getItemMulPatch(boolean small)
+{
+	UINT8 ofs = small ? 1 : 0;
+	return K_UseColorHud() ? kp_itemmulstickerclr[ofs] : kp_itemmulsticker[ofs];
 }
 
 static void K_drawKartStats(void)
@@ -7692,12 +7783,8 @@ static void K_drawKartItem(void)
 	const UINT8 offset = ((splitscreen > 1) ? 1 : 0);
 	patch_t *localpatch = kp_nodraw;
 	patch_t *localbg;
-	
-	if (cv_colorizeditembox.value && K_UseColorHud())
-		localbg = ((offset) ? kp_itembgclr[2] : kp_itembgclr[0]);
-	else
-		localbg = ((offset) ? kp_itembg[2] : kp_itembg[0]);
-	
+	boolean dark = false;
+
 	patch_t *localinv = ((offset) ? kp_invincibility[((leveltime % (6*3)) / 3) + 7] : kp_invincibility[(leveltime % (7*3)) / 3]);
 	INT32 fx = 0, fy = 0, fflags = 0;	// final coords for hud and flags...
 	//INT32 splitflags = K_calcSplitFlags(V_SNAPTOTOP|V_SNAPTOLEFT);
@@ -7708,9 +7795,9 @@ static void K_drawKartItem(void)
 	UINT8 localcolor = SKINCOLOR_NONE;
 	SINT8 colormode = TC_RAINBOW;
 	UINT8 *colmap = NULL;
-	UINT8 *colormap = R_GetTranslationColormap(TC_DEFAULT, K_GetHudColor(), GTC_CACHE);
-	
-	boolean flipamount = false;	// Used for 3P/4P splitscreen to flip item amount stuff
+	UINT8 *colormap = NULL;
+
+	boolean flipamount = splitscreen > 1 && stplyrnum & 1;	// Used for 3P/4P splitscreen to flip item amount stuff
 
 	if (stplyr->kartstuff[k_itemroulette])
 	{
@@ -7857,8 +7944,7 @@ static void K_drawKartItem(void)
 					break;
 				case KITEM_INVINCIBILITY:
 					localpatch = localinv;
-					if (cv_darkitembox.value)
-						localbg = (cv_colorizeditembox.value && K_UseColorHud()) ? kp_itembgclr[offset + 1] : kp_itembg[offset + 1];
+					dark = true;
 					break;
 				case KITEM_BANANA:
 					localpatch = kp_banana[offset];
@@ -7880,8 +7966,7 @@ static void K_drawKartItem(void)
 					break;
 				case KITEM_SPB:
 					localpatch = kp_selfpropelledbomb[offset];
-					if (cv_darkitembox.value)
-						localbg = (cv_colorizeditembox.value && K_UseColorHud()) ? kp_itembgclr[offset + 1] : kp_itembg[offset + 1];
+					dark = true;
 					break;
 				case KITEM_GROW:
 					localpatch = kp_grow[offset];
@@ -7891,8 +7976,7 @@ static void K_drawKartItem(void)
 					break;
 				case KITEM_THUNDERSHIELD:
 					localpatch = kp_thundershield[offset];
-					if (cv_darkitembox.value)
-						localbg = (cv_colorizeditembox.value && K_UseColorHud()) ? kp_itembgclr[offset + 1] : kp_itembg[offset + 1];
+					dark = true;
 					break;
 				case KITEM_HYUDORO:
 					localpatch = kp_hyudoro[offset];
@@ -7933,47 +8017,24 @@ static void K_drawKartItem(void)
 		}
 	}
 
-	// pain and suffering defined below
-	if (splitscreen < 2) // don't change shit for THIS splitscreen.
-	{
-		fx = ITEM_X;
-		fy = ITEM_Y;
-		fflags = K_calcSplitFlags(V_SNAPTOTOP|V_SNAPTOLEFT);
-	}
-	else // now we're having a fun game.
-	{
-		if (stplyr == &players[displayplayers[0]] || stplyr == &players[displayplayers[2]]) // If we are P1 or P3...
-		{
-			fx = ITEM_X;
-			fy = ITEM_Y;
-			fflags = V_SNAPTOLEFT|((stplyr == &players[displayplayers[2]]) ? V_SPLITSCREEN : V_SNAPTOTOP); // flip P3 to the bottom.
-		}
-		else // else, that means we're P2 or P4.
-		{
-			fx = ITEM2_X;
-			fy = ITEM2_Y;
-			fflags = V_SNAPTORIGHT|((stplyr == &players[displayplayers[3]]) ? V_SPLITSCREEN : V_SNAPTOTOP); // flip P4 to the bottom
-			flipamount = true;
-		}
-	}
+	localbg = K_getItemBoxPatch((boolean)offset, dark);
+	drawinfo_t info = K_getItemBoxDrawinfo();
+	fx = info.x;
+	fy = info.y;
+	fflags = info.flags;
 
 	if (localcolor != SKINCOLOR_NONE)
 		colmap = R_GetTranslationColormap(colormode, localcolor, GTC_CACHE);
+	if (K_UseColorHud())
+		colormap = R_GetTranslationColormap(TC_DEFAULT, K_GetHudColor(), GTC_CACHE);
 
-	
-	if (cv_colorizeditembox.value && K_UseColorHud())
-		V_DrawMappedPatch(fx, fy, V_HUDTRANS|fflags, localbg,colormap);
-	else
-		V_DrawScaledPatch(fx, fy, V_HUDTRANS|fflags, localbg);
+	V_DrawMappedPatch(fx, fy, V_HUDTRANS|fflags, localbg, cv_colorizeditembox.value ? colormap : NULL);
 
 	// Then, the numbers:
 	if (stplyr->kartstuff[k_itemamount] >= numberdisplaymin && !stplyr->kartstuff[k_itemroulette])
 	{
-		if (!K_UseColorHud())
-			V_DrawScaledPatch(fx + (flipamount ? 48 : 0), fy, V_HUDTRANS|fflags|(flipamount ? V_FLIP : 0), kp_itemmulsticker[offset]);
-		else  //Colourized hud
-			V_DrawMappedPatch(fx + (flipamount ? 48 : 0), fy, V_HUDTRANS|fflags|(flipamount ? V_FLIP : 0), kp_itemmulstickerclr[offset], colormap); // flip this graphic for p2 and p4 in split and shift it.
-		
+		localbg = K_getItemMulPatch((boolean)offset);
+		V_DrawMappedPatch(fx + (flipamount ? 48 : 0), fy, V_HUDTRANS|fflags|(flipamount ? V_FLIP : 0), localbg, colormap); // flip this graphic for p2 and p4 in split and shift it.
 		V_DrawFixedPatch(fx<<FRACBITS, fy<<FRACBITS, FRACUNIT, V_HUDTRANS|fflags, localpatch, colmap);
 		if (offset)
 			if (flipamount) // reminder that this is for 3/4p's right end of the screen.
@@ -8578,35 +8639,16 @@ static void K_drawKartLaps(void)
 {
 	INT32 splitflags = K_calcSplitFlags(V_SNAPTOBOTTOM|V_SNAPTOLEFT);
 	INT32 fx = 0, fy = 0, fflags = 0;	// stuff for 3p / 4p splitscreen.
-	boolean flipstring = false;	// used for 3p or 4p
+	boolean flipstring = splitscreen > 1 && stplyrnum & 1;  // used for 3p or 4p
 	INT32 stringw = 0;	// used with the above
-	
+
+	drawinfo_t info = K_getLapsDrawinfo();
+	fx = info.x;
+	fy = info.y;
+	fflags = info.flags;
+
 	if (splitscreen > 1)
 	{
-		// pain and suffering defined below
-		if (splitscreen < 2)	// don't change shit for THIS splitscreen.
-		{
-			fx = LAPS_X;
-			fy = LAPS_Y;
-			fflags = splitflags;
-		}
-		else
-		{
-			if (stplyr == &players[displayplayers[0]] || stplyr == &players[displayplayers[2]])	// If we are P1 or P3...
-			{
-				fx = LAPS_X;
-				fy = LAPS_Y;
-				fflags = V_SNAPTOLEFT|((stplyr == &players[displayplayers[2]]) ? V_SPLITSCREEN|V_SNAPTOBOTTOM : 0);	// flip P3 to the bottom.
-			}
-			else // else, that means we're P2 or P4.
-			{
-				fx = LAPS2_X;
-				fy = LAPS2_Y;
-				fflags = V_SNAPTORIGHT|((stplyr == &players[displayplayers[3]]) ? V_SPLITSCREEN|V_SNAPTOBOTTOM : 0);	// flip P4 to the bottom
-				flipstring = true;	// make the string right aligned and other shit
-			}
-		}
-
 		if (stplyr->exiting)	// draw stuff as god intended.
 		{
 			V_DrawScaledPatch(fx, fy, V_HUDTRANS|fflags, kp_splitlapflag);
@@ -8617,8 +8659,8 @@ static void K_drawKartLaps(void)
 			{
 				stringw = V_StringWidth(va("%d/%d", stplyr->laps+1, cv_numlaps.value), 0);
 
-				V_DrawScaledPatch(BASEVIDWIDTH-stringw-16, fy, V_HUDTRANS|fflags, kp_splitlapflag);
-				V_DrawRightAlignedString(BASEVIDWIDTH-3, fy+1, V_HUDTRANS|fflags, va("%d/%d", stplyr->laps+1, cv_numlaps.value));
+				V_DrawScaledPatch(fx-stringw-13, fy, V_HUDTRANS|fflags, kp_splitlapflag);
+				V_DrawRightAlignedString(fx, fy+1, V_HUDTRANS|fflags, va("%d/%d", stplyr->laps+1, cv_numlaps.value));
 			}
 			else	// draw stuff NORMALLY.
 			{
@@ -8631,23 +8673,23 @@ static void K_drawKartLaps(void)
 		if (!K_UseColorHud())
 		{
 			if (K_BigLapSticker())
-				V_DrawScaledPatch(LAPS_X, LAPS_Y, V_HUDTRANS|splitflags, ((stplyr->laps + 1 > 9) ? kp_lapstickerbig2 : kp_lapstickerbig));
+				V_DrawScaledPatch(fx, fy, V_HUDTRANS|splitflags, ((stplyr->laps + 1 > 9) ? kp_lapstickerbig2 : kp_lapstickerbig));
 			else
-				V_DrawScaledPatch(LAPS_X, LAPS_Y, V_HUDTRANS|splitflags, kp_lapsticker);
+				V_DrawScaledPatch(fx, fy, V_HUDTRANS|splitflags, kp_lapsticker);
 		}
 		else //Colourized hud
 		{
 			UINT8 *colormap = R_GetTranslationColormap(TC_DEFAULT, K_GetHudColor(), GTC_CACHE);
 			if (K_BigLapSticker())
-				V_DrawMappedPatch(LAPS_X, LAPS_Y, V_HUDTRANS|splitflags, ((stplyr->laps + 1 > 9) ? kp_lapstickerbig2clr : kp_lapstickerbigclr), colormap);
+				V_DrawMappedPatch(fx, fy, V_HUDTRANS|splitflags, ((stplyr->laps + 1 > 9) ? kp_lapstickerbig2clr : kp_lapstickerbigclr), colormap);
 			else
-				V_DrawMappedPatch(LAPS_X, LAPS_Y, V_HUDTRANS|splitflags, kp_lapstickerclr, colormap);
+				V_DrawMappedPatch(fx, fy, V_HUDTRANS|splitflags, kp_lapstickerclr, colormap);
 		}
 		
 		if (stplyr->exiting)
-			V_DrawKartString(LAPS_X+33, LAPS_Y+3, V_HUDTRANS|splitflags, "FIN");
+			V_DrawKartString(fx+33, fy+3, V_HUDTRANS|splitflags, "FIN");
 		else
-			V_DrawKartString(LAPS_X+33, LAPS_Y+3, V_HUDTRANS|splitflags, va("%d/%d", stplyr->laps+1, cv_numlaps.value));
+			V_DrawKartString(fx+33, fy+3, V_HUDTRANS|splitflags, va("%d/%d", stplyr->laps+1, cv_numlaps.value));
 	}
 }
 
@@ -8799,31 +8841,21 @@ static void K_drawKartSpeedometer(void)
 static void K_drawKartBumpersOrKarma(void)
 {
 	UINT8 *colormap = R_GetTranslationColormap(TC_DEFAULT, K_GetHudColor(), GTC_CACHE);
-	INT32 splitflags = K_calcSplitFlags(V_SNAPTOBOTTOM|V_SNAPTOLEFT);
-	INT32 fx = 0, fy = 0, fflags = 0;
-	boolean flipstring = false;	// same as laps, used for splitscreen
+	INT32 fx, fy, fflags;
+	boolean flipstring = splitscreen > 1 && stplyrnum & 1;  // same as laps, used for splitscreen
 	INT32 stringw = 0;	// used with the above
+
+	drawinfo_t info = K_getLapsDrawinfo();
+	fx = info.x;
+	fy = info.y;
+	fflags = info.flags;
 
 	if (splitscreen > 1)
 	{
-		// we will reuse lap coords here since it's essentially the same shit.
-
-		if (stplyr == &players[displayplayers[0]] || stplyr == &players[displayplayers[2]])	// If we are P1 or P3...
-		{
-			fx = LAPS_X;
-			fy = LAPS_Y;
-			fflags = V_SNAPTOLEFT|((stplyr == &players[displayplayers[2]]) ? V_SPLITSCREEN|V_SNAPTOBOTTOM : 0);	// flip P3 to the bottom.
-		}
-		else // else, that means we're P2 or P4.
-		{
-			fx = LAPS2_X;
-			fy = LAPS2_Y;
-			fflags = V_SNAPTORIGHT|((stplyr == &players[displayplayers[3]]) ? V_SPLITSCREEN|V_SNAPTOBOTTOM : 0);	// flip P4 to the bottom
-			flipstring = true;
-		}
-
 		if (stplyr->kartstuff[k_bumper] <= 0)
 		{
+			if (flipstring)
+				fx -= 37;
 			V_DrawMappedPatch(fx, fy-1, V_HUDTRANS|fflags, kp_splitkarmabomb, colormap);
 			V_DrawString(fx+13, fy+1, V_HUDTRANS|fflags, va("%d/2", stplyr->kartstuff[k_comebackpoints]));
 		}
@@ -8833,8 +8865,8 @@ static void K_drawKartBumpersOrKarma(void)
 			{
 				stringw = V_StringWidth(va("%d/%d", stplyr->kartstuff[k_bumper], cv_kartbumpers.value), 0);
 
-				V_DrawMappedPatch(BASEVIDWIDTH-stringw-16, fy-1, V_HUDTRANS|fflags, kp_rankbumper, colormap);
-				V_DrawRightAlignedString(BASEVIDWIDTH-3, fy+1, V_HUDTRANS|fflags, va("%d/%d", stplyr->kartstuff[k_bumper], cv_kartbumpers.value));
+				V_DrawMappedPatch(fx-stringw-13, fy-1, V_HUDTRANS|fflags, kp_rankbumper, colormap);
+				V_DrawRightAlignedString(fx, fy+1, V_HUDTRANS|fflags, va("%d/%d", stplyr->kartstuff[k_bumper], cv_kartbumpers.value));
 			}
 			else // draw bumpers normally.
 			{
@@ -8847,17 +8879,17 @@ static void K_drawKartBumpersOrKarma(void)
 	{
 		if (stplyr->kartstuff[k_bumper] <= 0)
 		{
-			V_DrawMappedPatch(LAPS_X, LAPS_Y, V_HUDTRANS|splitflags, (K_UseColorHud() ? kp_karmastickerclr : kp_karmasticker), colormap);
-			V_DrawKartString(LAPS_X+47, LAPS_Y+3, V_HUDTRANS|splitflags, va("%d/2", stplyr->kartstuff[k_comebackpoints]));
+			V_DrawMappedPatch(fx, fy, V_HUDTRANS|fflags, (K_UseColorHud() ? kp_karmastickerclr : kp_karmasticker), colormap);
+			V_DrawKartString(fx+47, fy+3, V_HUDTRANS|fflags, va("%d/2", stplyr->kartstuff[k_comebackpoints]));
 		}
 		else
 		{
 			if (stplyr->kartstuff[k_bumper] > 9 && cv_kartbumpers.value > 9)
-				V_DrawMappedPatch(LAPS_X, LAPS_Y, V_HUDTRANS|splitflags, (K_UseColorHud() ? kp_bumperstickerwideclr : kp_bumperstickerwide), colormap);
+				V_DrawMappedPatch(fx, fy, V_HUDTRANS|fflags, (K_UseColorHud() ? kp_bumperstickerwideclr : kp_bumperstickerwide), colormap);
 			else
-				V_DrawMappedPatch(LAPS_X, LAPS_Y, V_HUDTRANS|splitflags, (K_UseColorHud() ? kp_bumperstickerclr : kp_bumpersticker), colormap);
+				V_DrawMappedPatch(fx, fy, V_HUDTRANS|fflags, (K_UseColorHud() ? kp_bumperstickerclr : kp_bumpersticker), colormap);
 
-			V_DrawKartString(LAPS_X+47, LAPS_Y+3, V_HUDTRANS|splitflags, va("%d/%d", stplyr->kartstuff[k_bumper], cv_kartbumpers.value));
+			V_DrawKartString(fx+47, fy+3, V_HUDTRANS|fflags, va("%d/%d", stplyr->kartstuff[k_bumper], cv_kartbumpers.value));
 		}
 	}
 }
@@ -9120,7 +9152,7 @@ static void K_drawKartMinimap(void)
 	patch_t *AutomapPic;
 	INT32 i = 0;
 	INT32 x, y;
-	INT32 minimaptrans, splitflags = (splitscreen == 3 ? 0 : V_SNAPTORIGHT);	// flags should only be 0 when it's centered (4p split)
+	INT32 minimaptrans, splitflags;
 	SINT8 localplayers[4];
 	SINT8 numlocalplayers = 0;
 
@@ -9139,8 +9171,11 @@ static void K_drawKartMinimap(void)
 	else
 		return; // no pic, just get outta here
 
-	x = MINI_X - (AutomapPic->width/2);
-	y = MINI_Y - (AutomapPic->height/2);
+	drawinfo_t info = K_getMinimapDrawinfo();
+	x = info.x - (AutomapPic->width/2);
+	y = info.y - (AutomapPic->height/2);
+	splitflags = info.flags;
+
 
 	if (timeinmap > 105)
 	{

--- a/src/k_kart.h
+++ b/src/k_kart.h
@@ -106,9 +106,9 @@ typedef struct
 
 patch_t *K_getItemBoxPatch(boolean small, boolean dark);
 patch_t *K_getItemMulPatch(boolean small);
-drawinfo_t K_getItemBoxDrawinfo(void);
-drawinfo_t K_getLapsDrawinfo(void);
-drawinfo_t K_getMinimapDrawinfo(void);
+void K_getItemBoxDrawinfo(drawinfo_t *out);
+void K_getLapsDrawinfo(drawinfo_t *out);
+void K_getMinimapDrawinfo(drawinfo_t *out);
 
 // =========================================================================
 #endif  // __K_KART__

--- a/src/k_kart.h
+++ b/src/k_kart.h
@@ -18,6 +18,7 @@ void K_RainbowColormap(UINT8 *dest_colormap, UINT8 skincolor);
 void K_GenerateKartColormap(UINT8 *dest_colormap, INT32 skinnum, UINT8 color, boolean local);
 UINT8 K_GetKartColorByName(const char *name);
 UINT8 K_GetHudColor(void);
+boolean K_UseColorHud(void);
 
 void K_RegisterKartStuff(void);
 
@@ -95,6 +96,19 @@ void K_LoadKartHUDGraphics(void);
 void K_drawKartHUD(void);
 void K_drawKartFreePlay(UINT32 flashtime);
 void K_drawKartTimestamp(tic_t drawtime, INT32 TX, INT32 TY, INT16 emblemmap, UINT8 mode);
+
+typedef struct
+{
+	INT32 x;
+	INT32 y;
+	INT32 flags;
+} drawinfo_t;
+
+patch_t *K_getItemBoxPatch(boolean small, boolean dark);
+patch_t *K_getItemMulPatch(boolean small);
+drawinfo_t K_getItemBoxDrawinfo(void);
+drawinfo_t K_getLapsDrawinfo(void);
+drawinfo_t K_getMinimapDrawinfo(void);
 
 // =========================================================================
 #endif  // __K_KART__

--- a/src/lua_hudlib.c
+++ b/src/lua_hudlib.c
@@ -180,6 +180,48 @@ static const char *const hud_patch_options[] = {
 	"itemmul",
 	NULL};
 
+enum hudoffsets {
+	hudoffsets_item = 0,
+	hudoffsets_time,
+	hudoffsets_gametypeinfo,
+	hudoffsets_countdown,
+	hudoffsets_speedometer,
+	hudoffsets_position,
+	hudoffsets_minirankings,
+	hudoffsets_startcountdown,
+	hudoffsets_check,
+	hudoffsets_minimap,
+	hudoffsets_wanted,
+	hudoffsets_statdisplay
+};
+
+static const char *const hud_offsets_options[] = {
+	"item",
+	"time",
+	"gametypeinfo",
+	"countdown",
+	"speedometer",
+	"position",
+	"minirankings",
+	"startcountdown",
+	"check",
+	"minimap",
+	"wanted",
+	"statdisplay",
+	NULL};
+
+enum huddrawinfo {
+	huddrawinfo_item = 0,
+	huddrawinfo_gametypeinfo,
+	huddrawinfo_minimap
+};
+
+static const char *const hud_drawinfo_options[] = {
+	"item",
+	"gametypeinfo",
+	"minimap",
+	NULL};
+
 static int lib_getHudInfo(lua_State *L)
 {
 	UINT32 i;
@@ -1118,15 +1160,15 @@ static int libd_getlocaltransflag(lua_State *L)
 static int libd_getDrawInfo(lua_State *L)
 {
 	HUDONLY
-	enum hud option = luaL_checkoption(L, 1, NULL, hud_disable_options);
+	enum huddrawinfo option = luaL_checkoption(L, 1, NULL, hud_drawinfo_options);
 	drawinfo_t info;
 
 	switch(option) {
-		case hud_item:          info = K_getItemBoxDrawinfo();  break;
-		case hud_gametypeinfo:  info = K_getLapsDrawinfo();     break;
-		case hud_minimap:       info = K_getMinimapDrawinfo();  break;
+		case huddrawinfo_item:          info = K_getItemBoxDrawinfo();  break;
+		case huddrawinfo_gametypeinfo:  info = K_getLapsDrawinfo();     break;
+		case huddrawinfo_minimap:       info = K_getMinimapDrawinfo();  break;
 		default:
-			return 0; // not available
+			return 0; // unreachable
 	}
 
 	lua_pushinteger(L, info.x);
@@ -1254,28 +1296,29 @@ static int lib_hudsetvotebackground(lua_State *L)
 
 static int lib_hudgetoffsets(lua_State *L)
 {
-	enum hud option = luaL_checkoption(L, 1, NULL, hud_disable_options);
+	enum hudoffsets option = luaL_checkoption(L, 1, NULL, hud_offsets_options);
 	INT32 ofx, ofy;
 
-#define OFS(x, y) ofx = x.value; ofy = y.value; break;
-#define OFY(y) ofx = 0; ofy = y.value; break;
+#define OFS(it) ofx = cv_##it##_xoffset.value; ofy = cv_##it##_yoffset.value; break;
+#define OFY(it) ofx = 0; ofy = cv_##it##_yoffset.value; break;
 	switch(option) {
-		case hud_item:          OFS(cv_item_xoffset, cv_item_yoffset)
-		case hud_time:          OFS(cv_time_xoffset, cv_time_yoffset)
-		case hud_gametypeinfo:  OFS(cv_laps_xoffset, cv_laps_yoffset)
-		//case TODO:              OFS(cv_dnft_xoffset, cv_dnft_yoffset)
-		case hud_speedometer:   OFS(cv_speed_xoffset, cv_speed_yoffset)
-		case hud_position:      OFS(cv_posi_xoffset, cv_posi_yoffset)
-		case hud_minirankings:  OFS(cv_face_xoffset, cv_face_yoffset)
-		//case TODO:              OFS(cv_stcd_xoffset, cv_stcd_yoffset)
-		case hud_check:         OFY(cv_chek_yoffset);
-		case hud_minimap:       OFS(cv_mini_xoffset, cv_mini_yoffset)
-		case hud_wanted:        OFS(cv_want_xoffset, cv_want_yoffset)
-		case hud_statdisplay:   OFS(cv_stat_xoffset, cv_stat_yoffset)
+		case hudoffsets_item:           OFS(item)
+		case hudoffsets_time:           OFS(time)
+		case hudoffsets_gametypeinfo:   OFS(laps)
+		case hudoffsets_countdown:      OFS(dnft)
+		case hudoffsets_speedometer:    OFS(speed)
+		case hudoffsets_position:       OFS(posi)
+		case hudoffsets_minirankings:   OFS(face)
+		case hudoffsets_startcountdown: OFS(stcd)
+		case hudoffsets_check:          OFY(chek)
+		case hudoffsets_minimap:        OFS(mini)
+		case hudoffsets_wanted:         OFS(want)
+		case hudoffsets_statdisplay:    OFS(stat)
 		default:
-			return 0; // not available
+			return 0; // unreachable
 	}
 #undef OFS
+#undef OFY
 
 	lua_pushinteger(L, ofx);
 	lua_pushinteger(L, ofy);

--- a/src/lua_hudlib.c
+++ b/src/lua_hudlib.c
@@ -1164,9 +1164,9 @@ static int libd_getDrawInfo(lua_State *L)
 	drawinfo_t info;
 
 	switch(option) {
-		case huddrawinfo_item:          info = K_getItemBoxDrawinfo();  break;
-		case huddrawinfo_gametypeinfo:  info = K_getLapsDrawinfo();     break;
-		case huddrawinfo_minimap:       info = K_getMinimapDrawinfo();  break;
+		case huddrawinfo_item:          K_getItemBoxDrawinfo(&info);  break;
+		case huddrawinfo_gametypeinfo:  K_getLapsDrawinfo(&info);     break;
+		case huddrawinfo_minimap:       K_getMinimapDrawinfo(&info);  break;
 		default:
 			return 0; // unreachable
 	}

--- a/src/p_enemy.c
+++ b/src/p_enemy.c
@@ -33,7 +33,6 @@
 boolean LUA_CallAction(const char *action, mobj_t *actor);
 #endif
 
-player_t *stplyr;
 INT32 var1;
 INT32 var2;
 

--- a/src/p_local.h
+++ b/src/p_local.h
@@ -306,9 +306,6 @@ void P_FlashPal(player_t *pl, UINT16 type, UINT16 duration);
 // P_ENEMY
 //
 
-// main player in game
-extern player_t *stplyr; // for splitscreen correct palette changes and overlay
-
 // Is there a better place for these?
 extern INT32 var1;
 extern INT32 var2;

--- a/src/st_stuff.c
+++ b/src/st_stuff.c
@@ -150,6 +150,10 @@ static patch_t *hud_tv2;
 static patch_t *envelope;
 #endif
 
+// current player for overlay drawing
+player_t *stplyr;
+UINT8 stplyrnum;
+
 // SRB2kart
 
 hudinfo_t hudinfo[NUMHUDITEMS] =
@@ -2223,6 +2227,7 @@ void ST_Drawer(void)
 		for (i = 0; i <= splitscreen; i++)
 		{
 			stplyr = &players[displayplayers[i]];
+			stplyrnum = i;
 			ST_overlayDrawer();
 		}
 

--- a/src/st_stuff.h
+++ b/src/st_stuff.h
@@ -68,6 +68,8 @@ boolean ST_SameTeam(player_t *a, player_t *b);
 
 extern boolean st_overlay; // sb overlay on or off when fullscreen
 extern INT32 st_palette; // 0 is default, any others are special palettes.
+extern player_t *stplyr; // for splitscreen correct palette changes and overlay
+extern UINT8 stplyrnum;
 
 extern lumpnum_t st_borderpatchnum;
 // patches, also used in intermission


### PR DESCRIPTION
Currently, supporting Saturn's HUD customization in Lua is kind of a pain.
There's lots of cvars to deal with, like `colorizedhud`, `colorizedhudcolor`, `xoffset`, `yoffset`, lots of hardcode to copy and paste...
It's especially painful for the item box, which has its own pair of cvars: `colorizeditembox` and `darkitembox`.
And what if any of the above changes? Now you have to update your scripts to support it!

This PR introduces a set of new Lua functions that greatly simplifies supporting HUD customization.

`x, y = hud.getOffsets(item)`
Returns the values of the given HUD item's offset cvars. ~~Takes the same input as `hud.enabled`. Returns nil if the item doesn't support offsets. (TODO: error out instead?)~~ Now it does, and supports HUD items not in ``hud.enabled``.

`x, y, flags = v.getDrawInfo(item)`
Returns the X, Y and flags where the given HUD item will be drawn. Currently supported are `item`, `gametypeinfo` (laps) and `minimap`. More can be added in the future.
Some refactoring was done for this one; a new `drawinfo_t` has been introduced, so Lua and hardcode can share the same logic for positioning HUD items.
This function might seem redundant, but it allows separating the offset cvars from the drawing logic. And I've got some plans for that 😛 

`v.drawItemBox(x, y, flags, small, dark, colormap)`
~~Draws an item box. The size and darkness of the item box can be controlled, as well as the color. If no colormap is provided, it uses the default HUD colormap.
Colorization is automatically enabled depending on the player's settings.~~

`v.drawItemMul(x, y, flags, small, colormap)`
~~Draws the multi sticker. It's not as complex as the item box, but it's closely related, so it's included for convenience. (doesn't flip automatically, btw)~~

`hudcolor = v.getHudColor()`
Returns the skincolor used for HUD colorization. Useful for colorizing your own HUD stuff.

`colorized = v.useColorHud()`
Returns true if HUD colorization is enabled.

All in all, there's room for improvement, but the Lua side of things is pretty much done.

Some extras:
* Fixed `V_SPLITSCREEN` on OpenGL. It's about time, huh?
* Added `stplyrnum` to simplify HUD code. Also moved it (and `stplyr`) to st_stuff.h where it belongs.