### PR TITLE
Add gr_glinfo.

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -134,6 +134,7 @@ set(SRB2_CORE_RENDER_SOURCES
 	r_sky.c
 	r_splats.c
 	r_things.c
+	r_portal.c
 
 	r_bsp.h
 	r_data.h
@@ -149,6 +150,7 @@ set(SRB2_CORE_RENDER_SOURCES
 	r_splats.h
 	r_state.h
 	r_things.h
+	r_portal.h
 )
 
 set(SRB2_CORE_GAME_SOURCES
@@ -488,7 +490,7 @@ if(${SRB2_CONFIG_HWRENDER})
 		${CMAKE_CURRENT_SOURCE_DIR}/hardware/hw_drv.h
 		${CMAKE_CURRENT_SOURCE_DIR}/hardware/hw_glob.h
 		${CMAKE_CURRENT_SOURCE_DIR}/hardware/hw_main.h
-		${CMAKE_CURRENT_SOURCE_DIR}/hardware/hw_portal.c
+		${CMAKE_CURRENT_SOURCE_DIR}/hardware/hw_portal.h
 		${CMAKE_CURRENT_SOURCE_DIR}/hardware/hw_md2.h
 		${CMAKE_CURRENT_SOURCE_DIR}/hardware/hw_md2load.h
 		${CMAKE_CURRENT_SOURCE_DIR}/hardware/hw_md3load.h

--- a/src/hardware/hw_main.c
+++ b/src/hardware/hw_main.c
@@ -141,6 +141,8 @@ static void HWR_TogglePaletteRendering(void);
 // ==========================================================================
 // Commands and console variables
 // ==========================================================================
+static void HWR_RegisterCommands(void);
+static void COM_HWR_glinfo(void);
 
 //
 // Onchanges
@@ -5411,8 +5413,60 @@ void HWR_Startup(void)
 
 		if (msaa)
 			HWD.pfnSetSpecialState(HWD_SET_MSAA, a2c ? 2 : 1);
+
+		HWR_RegisterCommands();
 	}
 	startupdone = true;
+}
+
+/**
+ * Register renderer commands.
+ */
+static void HWR_RegisterCommands(void)
+{
+	COM_AddCommand("gr_glinfo", COM_HWR_glinfo);
+}
+
+static void COM_HWR_glinfo(void)
+{
+	if (vid.glstate != VID_GL_LIBRARY_LOADED)
+	{
+		CONS_Printf("Currently not using the OpenGL renderer.\n");
+		return;
+	}
+
+	int list_extensions = 0;
+	size_t argc = COM_Argc();
+	const char *argv;
+	for (size_t i = 1; i < argc; i++)
+	{
+		argv = COM_Argv(i);
+
+		if (strcmp(argv, "--list-extensions") == 0 || strcmp(argv, "-l") == 0)
+		{
+			list_extensions = 1;
+		}
+		else
+		{
+			CONS_Printf("Unrecognized argument: %s\n", argv);
+			return;
+		}
+		
+	}
+
+	CONS_Printf("\x88OpenGL %s\x80\n", gl_version);
+	CONS_Printf("Renderer: %s\n", gl_renderer);
+	CONS_Printf("Vendor: %s\n", gl_vendor);
+
+	CONS_Printf("%u GL extensions present.\n", gl_num_extensions);
+	if (list_extensions)
+	{
+		CONS_Printf("%s\n", gl_extensions);
+	}
+	else
+	{
+		CONS_Printf("Use --list-extensions to view the list of extensions.\n");
+	}
 }
 
 // --------------------------------------------------------------------------

--- a/src/hardware/r_opengl/r_opengl.c
+++ b/src/hardware/r_opengl/r_opengl.c
@@ -112,6 +112,7 @@ const GLubyte *gl_version = NULL;
 const GLubyte *gl_renderer = NULL;
 const GLubyte *gl_extensions = NULL;
 const GLubyte *gl_vendor = NULL;
+GLuint gl_num_extensions;
 
 // Loaded OpenGL version
 int majorGL = 0, minorGL = 0;

--- a/src/hardware/r_opengl/r_opengl.c
+++ b/src/hardware/r_opengl/r_opengl.c
@@ -111,6 +111,7 @@ static FTransform  md2_transform;
 const GLubyte *gl_version = NULL;
 const GLubyte *gl_renderer = NULL;
 const GLubyte *gl_extensions = NULL;
+const GLubyte *gl_vendor = NULL;
 
 // Loaded OpenGL version
 int majorGL = 0, minorGL = 0;

--- a/src/hardware/r_opengl/r_opengl.h
+++ b/src/hardware/r_opengl/r_opengl.h
@@ -120,6 +120,7 @@ extern const GLubyte	*gl_version;
 extern const GLubyte	*gl_renderer;
 extern const GLubyte	*gl_extensions;
 extern const GLubyte    *gl_vendor;
+extern GLuint     gl_num_extensions;
 
 extern int 				majorGL, minorGL;
 

--- a/src/hardware/r_opengl/r_opengl.h
+++ b/src/hardware/r_opengl/r_opengl.h
@@ -119,6 +119,7 @@ extern boolean supportFBO;
 extern const GLubyte	*gl_version;
 extern const GLubyte	*gl_renderer;
 extern const GLubyte	*gl_extensions;
+extern const GLubyte    *gl_vendor;
 
 extern int 				majorGL, minorGL;
 

--- a/src/m_menu.c
+++ b/src/m_menu.c
@@ -3473,7 +3473,9 @@ void SaturnHud_menu_Onchange(void)
 #ifdef HWRENDER
 void M_UpdateOGLMenu(void)
 {
+#ifdef USE_FBO_OGL
 	OP_ExpOptionsMenu[op_exp_fbo].status = (!supportFBO || cv_glscreentextures.value != 2) ? IT_GRAYEDOUT : IT_STRING | IT_CVAR;
+#endif
 	OP_ExpOptionsMenu[op_exp_paldepth].status = (!HWR_ShouldUsePaletteRendering()) ? IT_GRAYEDOUT : IT_STRING | IT_CVAR;
 
 	OP_OpenGLOptionsMenu[op_gl_falbckmdls].status = (!cv_glmdls.value) ? IT_GRAYEDOUT : IT_STRING | IT_CVAR;

--- a/src/sdl/ogl_sdl.c
+++ b/src/sdl/ogl_sdl.c
@@ -149,7 +149,7 @@ boolean OglSdlSurface(INT32 w, INT32 h)
 		gl_version = pglGetString(GL_VERSION);
 		gl_renderer = pglGetString(GL_RENDERER);
 		gl_extensions = pglGetString(GL_EXTENSIONS);
-		pglGetIntegerv(GL_NUM_EXTENSIONS, &gl_num_extensions);
+		pglGetIntegerv(GL_NUM_EXTENSIONS, (GLint*)&gl_num_extensions);
 		gl_vendor = pglGetString(GL_VENDOR);
 
 		GL_DBG_Printf("OpenGL %s\n", gl_version);

--- a/src/sdl/ogl_sdl.c
+++ b/src/sdl/ogl_sdl.c
@@ -149,6 +149,7 @@ boolean OglSdlSurface(INT32 w, INT32 h)
 		gl_version = pglGetString(GL_VERSION);
 		gl_renderer = pglGetString(GL_RENDERER);
 		gl_extensions = pglGetString(GL_EXTENSIONS);
+		gl_vendor = pglGetString(GL_VENDOR);
 
 		GL_DBG_Printf("OpenGL %s\n", gl_version);
 		GL_DBG_Printf("GPU: %s\n", gl_renderer);

--- a/src/sdl/ogl_sdl.c
+++ b/src/sdl/ogl_sdl.c
@@ -149,6 +149,7 @@ boolean OglSdlSurface(INT32 w, INT32 h)
 		gl_version = pglGetString(GL_VERSION);
 		gl_renderer = pglGetString(GL_RENDERER);
 		gl_extensions = pglGetString(GL_EXTENSIONS);
+		pglGetIntegerv(GL_NUM_EXTENSIONS, &gl_num_extensions);
 		gl_vendor = pglGetString(GL_VENDOR);
 
 		GL_DBG_Printf("OpenGL %s\n", gl_version);


### PR DESCRIPTION
Add a command `gr_glinfo` that can view the OpenGL version, renderer and driver vendor, as well as any extensions avaiable with the `-l`/`--list-extensions` argument.

This command is particularly useful for learning the hardware capabilities of the hardware renderer providing the OpenGL API. It might also come handy when requesting information from users in issues, especially those related to graphics.