### PR TITLE
Add a dial speedometer

### DIFF
--- a/src/d_main.c
+++ b/src/d_main.c
@@ -1208,6 +1208,8 @@ boolean xtra_speedo3 = false;      // 80x 11 extra speedometer check
 boolean xtra_speedo_clr3 = false;  // 80x 11 extra speedometer colour check
 boolean achi_speedo = false;       // achiiro speedometer check
 boolean achi_speedo_clr = false;   // extra speedometer colour check
+boolean dial_speedo = false;       // dial speedometer check
+boolean dial_speedo_clr = false;   // dial speedometer colour check
 boolean kartz_speedo = false;      // kartZ speedo
 boolean kartz_speedo_smol = false; // kartZ speedo but smol
 
@@ -1337,7 +1339,7 @@ static inline void D_MakeTitleString(char *s)
 static void D_CheckSaturnExtraFiles(void)
 {
 	// Possible value that changes depending on whether required files for speedometer are found or not
-	CV_PossibleValue_t speedo_cons_temp[NUMSPEEDOSTUFF] = {{1, "Default"}, {0, NULL}, {0, NULL}, {0, NULL}, {0, NULL}, {0, NULL}, {0, NULL}};
+	CV_PossibleValue_t speedo_cons_temp[NUMSPEEDOSTUFF] = {{1, "Default"}, {0, NULL}, {0, NULL}, {0, NULL}, {0, NULL}, {0, NULL}, {0, NULL}, {0, NULL}};
 	CV_PossibleValue_t driftgaugestyle_cons_temp[NUMDGAUGESTUFF] = {{1, "Default"}, {2, "Small"}, {3, "Big Numbers"}, {4, "Numbers Only"}, {0, NULL}, {0, NULL}};
 	CV_PossibleValue_t inputdisplay_cons_temp[NUMINPUTDISPLAYSTUFF] = {{0, "Off"}, {1, "Wheel"}, {2, "Stick"}, {0, NULL}, {0, NULL}};
 
@@ -1365,6 +1367,17 @@ static void D_CheckSaturnExtraFiles(void)
 			PUSHCONS(speedo_cons_temp, last_speedo_i, 3, "Achii");
 		}
 
+		// now check for dial speedometer stuff
+		if (W_CheckMultipleLumps("K_DSPBS1", "K_DSPBS2", "K_DSDIAL",
+			"K_TRNULL", "SP_DKMH", "SP_DMPH", "SP_DFRAC", "SP_DPERC",
+			"K_DSPNM0", "K_DSPNM1", "K_DSPNM2", "K_DSPNM3", "K_DSPNM4",
+			"K_DSPNM5", "K_DSPNM6", "K_DSPNM7", "K_DSPNM8", "K_DSPNM9",
+			"RANKFIN", NULL))
+		{
+			dial_speedo = true;
+			PUSHCONS(speedo_cons_temp, last_speedo_i, 4, "Dial");
+		}
+
 		// check for bigger lap count
 		if (W_CheckMultipleLumps("K_STLAPB", "K_STLA2B", NULL))
 		{
@@ -1378,7 +1391,7 @@ static void D_CheckSaturnExtraFiles(void)
 			"K_KZSP20", "K_KZSP21", "K_KZSP22", "K_KZSP23", "K_KZSP24", "K_KZSP25", NULL))
 		{
 			kartz_speedo = true;
-			PUSHCONS(speedo_cons_temp, last_speedo_i, 4, "P-Meter");
+			PUSHCONS(speedo_cons_temp, last_speedo_i, 5, "P-Meter");
 		}
 
 		if (W_CheckMultipleLumps("K_KZSS1", "K_KZSS2", "K_KZSS3", "K_KZSS4", "K_KZSS5",
@@ -1387,7 +1400,7 @@ static void D_CheckSaturnExtraFiles(void)
 			"K_KZSS20", "K_KZSS21", "K_KZSS22", "K_KZSS23", "K_KZSS24", "K_KZSS25", NULL))
 		{
 			kartz_speedo_smol = true;
-			PUSHCONS(speedo_cons_temp, last_speedo_i, 5, "P-Meter Small");
+			PUSHCONS(speedo_cons_temp, last_speedo_i, 6, "P-Meter Small");
 		}
 
 		// stat display for extended player setup
@@ -1447,6 +1460,16 @@ static void D_CheckSaturnExtraFiles(void)
 			achi_speedo_clr = true;
 		}
 
+		// dial speedo but colour
+		if (W_CheckMultipleLumps("K_DSPBC1", "K_DSPBC2", "K_DSDIAL",
+			"K_TRNULL", "SC_DKMH", "SC_DMPH", "SC_DFRAC", "SC_DPERC",
+			"K_DSPNC0", "K_DSPNC1", "K_DSPNC2", "K_DSPNC3", "K_DSPNC4",
+			"K_DSPNC5", "K_DSPNC6", "K_DSPNC7", "K_DSPNC8", "K_DSPNC9",
+			"RANKFIN", NULL))
+		{
+			dial_speedo_clr = true;
+		}
+
 		// driftgauge but colour
 		if (W_CheckMultipleLumps("K_DCAU","K_DCSU", NULL))
 		{
@@ -1470,7 +1493,7 @@ static void D_CheckSaturnExtraFiles(void)
 		if (W_LumpExists("SP_SM3TC"))
 		{
 			xtra_speedo3 = true;
-			PUSHCONS(speedo_cons_temp, last_speedo_i, 6, "Extra");
+			PUSHCONS(speedo_cons_temp, last_speedo_i, 7, "Extra");
 			PUSHCONS(driftgaugestyle_cons_temp, last_driftgauge_i, 5, "Extra");
 		}
 

--- a/src/d_main.h
+++ b/src/d_main.h
@@ -38,6 +38,8 @@ extern boolean xtra_speedo3;      // 80x11 extra speedometer check
 extern boolean xtra_speedo_clr3;  // 80x11 extra speedometer colour check
 extern boolean achi_speedo;       // achiiro speedometer check
 extern boolean achi_speedo_clr;   // extra speedometer colour check
+extern boolean dial_speedo;       // dial speedometer check
+extern boolean dial_speedo_clr;   // dial speedometer colour check
 extern boolean kartz_speedo;      // kartZ speedo
 extern boolean kartz_speedo_smol; // kartZ speedo but smol
 

--- a/src/k_kart.c
+++ b/src/k_kart.c
@@ -8393,7 +8393,7 @@ static void K_drawKartStats(void)
 	else
 		spdoffset = 0;
 
-	if (speedostyle != SPEEDO_DIAL)
+	if ((speedostyle != SPEEDO_DIAL) || (splitscreen))
 		spdoffset += (G_BattleGametype() ? (stplyr->kartstuff[k_bumper] ? -5 : -8) : 0);
 
 	// Customizations c:
@@ -11412,11 +11412,45 @@ static void K_drawCheckpointDebugger(void)
 	V_DrawString(8, 192, 0, va("Waypoint dist: Prev %d, Next %d", stplyr->kartstuff[k_prevcheck], stplyr->kartstuff[k_nextcheck]));
 }
 
+// determines if gametype info (laps/bumpers) should be hidden
+static boolean K_DisableGametypeInfo(void)
+{
+	if (!LUA_HudEnabled(hud_gametypeinfo))
+	{
+		return true;
+	}
+
+#ifdef ROTSPRITE
+	if (splitscreen || (!cv_kartspeedometer.value))
+	{
+		// don't need to run checks if we're in splitscreen, or not using the speedometer
+		return false;
+	}
+
+	const UINT8 speedostyle = K_GetSpeedometerStyle();
+
+	if (G_RaceGametype())
+	{
+		if (speedostyle == SPEEDO_DIAL)
+			return true;
+	}
+	else if (G_BattleGametype())
+	{
+		if ((cv_battlespeedo.value) && (speedostyle == SPEEDO_DIAL))
+			return true;
+	}
+#endif
+
+	return false;
+}
+
+
 void K_drawKartHUD(void)
 {
 	boolean isfreeplay = false;
 	boolean battlefullscreen = false;
 	boolean freecam = camera[stplyrnum].freecam;	//disable some hud elements w/ freecam
+	boolean gameinfovisible = false;
 
 	// Define the X and Y for each drawn object
 	// This is handled by console/menu values
@@ -11432,8 +11466,6 @@ void K_drawKartHUD(void)
 		K_drawChallengerScreen();
 		return;
 	}
-
-	const UINT8 speedostyle = K_GetSpeedometerStyle();
 
 	battlefullscreen = ((G_BattleGametype())
 		&& (stplyr->exiting
@@ -11524,6 +11556,9 @@ void K_drawKartHUD(void)
 
 	if (!stplyr->spectator && !freecam) // Bottom of the screen elements, don't need in spectate mode
 	{
+		// get gametype info visibility ahead of time
+		gameinfovisible = (!K_DisableGametypeInfo());
+
 		if (!(splitscreen || demo.title))
 		{
 			if (LUA_HudEnabled(hud_inputdisplay))
@@ -11564,7 +11599,7 @@ void K_drawKartHUD(void)
 		else if (G_RaceGametype()) // Race-only elements
 		{
 			// Draw the lap counter
-			if ((LUA_HudEnabled(hud_gametypeinfo)) && ((!cv_kartspeedometer.value) || (speedostyle != SPEEDO_DIAL)))
+			if (gameinfovisible)
 				K_drawKartLaps();
 
 			if (!splitscreen)
@@ -11587,7 +11622,7 @@ void K_drawKartHUD(void)
 		else if (G_BattleGametype()) // Battle-only
 		{
 			// Draw the hits left!
-			if ((LUA_HudEnabled(hud_gametypeinfo)) && ((!cv_battlespeedo.value) || (speedostyle != SPEEDO_DIAL)))
+			if (gameinfovisible)
 				K_drawKartBumpersOrKarma();
 
 			if ((!splitscreen) && cv_battlespeedo.value)

--- a/src/k_kart.c
+++ b/src/k_kart.c
@@ -9449,6 +9449,7 @@ static void K_drawKartLaps(void)
 #ifdef ROTSPRITE
 
 #define DIALSPDDIV 97090 // 1.48148; converts 200 to 135
+#define MPHDIV 68283 // 1.04192; converts 141 to 135
 
 static void K_DrawDialNum(INT32 x, INT32 y, boolean colorized, INT32 flags, INT32 num, INT32 digits, const UINT8 *colormap)
 {
@@ -9489,6 +9490,7 @@ static void K_DrawDialLaps(INT32 x, INT32 y, INT32 num, INT32 total, INT32 flags
 }
 
 static void K_DrawDialSpeedometer(fixed_t speed,
+								  fixed_t divisor,
 								  INT32 splitflags,
 								  boolean battlemode,
 								  boolean infoactive,
@@ -9501,7 +9503,7 @@ static void K_DrawDialSpeedometer(fixed_t speed,
 	patch_t* dialpatch;
 
 	angle_t speedangle =
-		FixedAngle(((FixedDiv(min(200 * FRACUNIT, speed), DIALSPDDIV) - (45 * FRACUNIT))));
+		FixedAngle(((min(135 * FRACUNIT, FixedDiv(speed, divisor)) - (45 * FRACUNIT))));
 
 	rot = R_GetRollAngle(speedangle);
 
@@ -9590,8 +9592,6 @@ static void K_DrawDialSpeedometer(fixed_t speed,
 	}
 }
 
-#undef DIALSPDDIV
-
 #endif
 
 static void K_drawKartSpeedometer(void)
@@ -9602,6 +9602,7 @@ static void K_drawKartSpeedometer(void)
 
 	// index 0 is the raw value, index 1 is the converted value
 	fixed_t convSpeed[2] = {0,0};
+	fixed_t dial_divisor = DIALSPDDIV;
 
 	INT32 splitflags = K_calcSplitFlags(V_SNAPTOBOTTOM|V_SNAPTOLEFT);
 
@@ -9617,10 +9618,12 @@ static void K_drawKartSpeedometer(void)
 		case 2:
 			convSpeed[0] = FixedDiv(FixedMul(stplyr->speed, 88465), mapobjectscale); // 1.349868774
 			convSpeed[1] = convSpeed[0] / FRACUNIT;
+			dial_divisor = MPHDIV;
 			break;
 		case 3:
 			convSpeed[0] = FixedDiv(stplyr->speed, mapobjectscale);
 			convSpeed[1] = convSpeed[0] / FRACUNIT;
+			dial_divisor = MPHDIV;
 			break;
 		case 4:
 			if (stplyr->mo)
@@ -9694,6 +9697,7 @@ static void K_drawKartSpeedometer(void)
 	else if (speedostyle == SPEEDO_DIAL)  // why bother if we dont?
 	{
 		K_DrawDialSpeedometer(convSpeed[0],
+							dial_divisor,
 							splitflags,
 							(boolean)(G_BattleGametype()),
 							(LUA_HudEnabled(hud_gametypeinfo)),
@@ -9750,6 +9754,11 @@ static void K_drawKartSpeedometer(void)
 		V_DrawScaledPatch(SPDM_X, SPDM_Y, V_HUDTRANS|splitflags, patch);
 	}
 }
+
+#ifdef ROTSPRITE
+#undef DIALSPDDIV
+#undef MPHDIV
+#endif
 
 static void K_drawKartBumpersOrKarma(void)
 {

--- a/src/k_kart.c
+++ b/src/k_kart.c
@@ -747,6 +747,7 @@ enum
 	SPEEDO_VANILLA,
 	SPEEDO_EXTRA,
 	SPEEDO_ACHII,
+	SPEEDO_DIAL,
 	SPEEDO_PMETER,
 	SPEEDO_PMETERSMOL,
 	SPEEDO_EXTRA3,
@@ -758,11 +759,13 @@ static UINT8 K_GetSpeedometerStyle(void)
 		return SPEEDO_EXTRA;
 	else if (cv_newspeedometer.value == 3 && achi_speedo)
 		return SPEEDO_ACHII;
-	else if (cv_newspeedometer.value == 4 && kartz_speedo)
+		else if (cv_newspeedometer.value == 4 && dial_speedo)
+		return SPEEDO_DIAL;
+	else if (cv_newspeedometer.value == 5 && kartz_speedo)
 		return SPEEDO_PMETER;
-	else if (cv_newspeedometer.value == 5 && kartz_speedo_smol)
+	else if (cv_newspeedometer.value == 6 && kartz_speedo_smol)
 		return SPEEDO_PMETERSMOL;
-	else if (cv_newspeedometer.value == 6 && xtra_speedo3)
+	else if (cv_newspeedometer.value == 7 && xtra_speedo3)
 		return SPEEDO_EXTRA3;
 	else
 		return SPEEDO_VANILLA;
@@ -7558,6 +7561,16 @@ static patch_t *skp_speedpatchesachi[5];
 static patch_t *skp_smallstickerachiclr;
 static patch_t *skp_speedpatchesachiclr[5];
 
+// dial speedometer
+static patch_t *skp_rankfinish;
+static patch_t *skp_dialbase[2];
+static patch_t *skp_speedpatchesdial[5];
+static patch_t *skp_dialnum[10];
+//static patch_t *skp_dialclr;
+static patch_t *skp_dialbaseclr[2];
+static patch_t *skp_speedpatchesdialclr[5];
+static patch_t *skp_dialnumclr[10];
+
 static patch_t *joybacking;
 static patch_t *joyknob;
 static patch_t *joyshadow;
@@ -7608,6 +7621,26 @@ void K_LoadKartHUDGraphics(void)
 		skp_speedpatchesachi[4] = W_CachePatchName("SP_APERC", PU_HUDGFX);
 	}
 
+	if (dial_speedo)
+	{
+		skp_rankfinish =		  W_CachePatchName("RANKFIN",  PU_HUDGFX);
+		skp_dialbase[0] = 	      W_CachePatchName("K_DSPBS1", PU_HUDGFX);
+		skp_dialbase[1] = 	      W_CachePatchName("K_DSPBS2", PU_HUDGFX);
+
+		skp_speedpatchesdial[0] = W_CachePatchName("K_TRNULL", PU_HUDGFX); // lolxd
+		skp_speedpatchesdial[1] = W_CachePatchName("SP_DKMH",  PU_HUDGFX);
+		skp_speedpatchesdial[2] = W_CachePatchName("SP_DMPH",  PU_HUDGFX);
+		skp_speedpatchesdial[3] = W_CachePatchName("SP_DFRAC", PU_HUDGFX);
+		skp_speedpatchesdial[4] = W_CachePatchName("SP_DPERC", PU_HUDGFX);
+
+		sprintf(buffer, "K_DSPNMx");
+		for (i = 0; i < 10; i++)
+		{
+			buffer[7] = '0'+(i%10);
+			skp_dialnum[i] = (patch_t *) W_CachePatchName(buffer, PU_HUDGFX);
+		}
+	}
+
 	if (big_lap)
 	{
 		kp_lapstickerbig = 		W_CachePatchName("K_STLAPB", PU_HUDGFX);
@@ -7653,6 +7686,25 @@ void K_LoadKartHUDGraphics(void)
 		skp_speedpatchesachiclr[2] = W_CachePatchName("SC_AMPH",  PU_HUDGFX);
 		skp_speedpatchesachiclr[3] = W_CachePatchName("SC_AFRAC", PU_HUDGFX);
 		skp_speedpatchesachiclr[4] = W_CachePatchName("SC_APERC", PU_HUDGFX);
+	}
+
+	if (dial_speedo && dial_speedo_clr)
+	{
+		skp_dialbaseclr[0] = 	     W_CachePatchName("K_DSPBC1", PU_HUDGFX);
+		skp_dialbaseclr[1] = 	     W_CachePatchName("K_DSPBC2", PU_HUDGFX);
+
+		skp_speedpatchesdialclr[0] = W_CachePatchName("K_TRNULL", PU_HUDGFX); // lolxd
+		skp_speedpatchesdialclr[1] = W_CachePatchName("SC_DKMH",  PU_HUDGFX);
+		skp_speedpatchesdialclr[2] = W_CachePatchName("SC_DMPH",  PU_HUDGFX);
+		skp_speedpatchesdialclr[3] = W_CachePatchName("SC_DFRAC", PU_HUDGFX);
+		skp_speedpatchesdialclr[4] = W_CachePatchName("SC_DPERC", PU_HUDGFX);
+
+		sprintf(buffer, "K_DSPNCx");
+		for (i = 0; i < 10; i++)
+		{
+			buffer[7] = '0'+(i%10);
+			skp_dialnumclr[i] = (patch_t *) W_CachePatchName(buffer, PU_HUDGFX);
+		}
 	}
 
 	// KartZ speedo
@@ -8301,12 +8353,14 @@ patch_t *K_getItemMulPatch(boolean small)
 
 static void K_drawKartStats(void)
 {
-	INT32 x, y, spdoffset, flags;
+	INT32 x, y, spdxoffset, spdoffset, flags;
 
 	// For 1-player display
 	x = 15;
 	y = 150;
+	spdxoffset = 0;
 	spdoffset = 0;
+
 	flags = V_SNAPTOBOTTOM|V_SNAPTOLEFT;
 
 	UINT8 splitnum = 0;
@@ -8321,29 +8375,38 @@ static void K_drawKartStats(void)
 		return;
 
 	//Internal offset for speedometer
-	if (cv_kartspeedometer.value)
-	{
-		const UINT8 speedostyle = K_GetSpeedometerStyle();
 
+	const UINT8 speedostyle = K_GetSpeedometerStyle();
+
+	if (cv_kartspeedometer.value && (!splitscreen))
+	{
 		if ((speedostyle == SPEEDO_EXTRA) || (speedostyle == SPEEDO_ACHII) || (speedostyle == SPEEDO_EXTRA3))
 			spdoffset = -10;
+		else if (speedostyle == SPEEDO_DIAL)
+		{
+			spdxoffset = 11;
+			spdoffset = 14;
+		}
 		else
 			spdoffset = -14;
 	}
 	else
 		spdoffset = 0;
 
+	if (speedostyle != SPEEDO_DIAL)
+		spdoffset += (G_BattleGametype() ? (stplyr->kartstuff[k_bumper] ? -5 : -8) : 0);
+
 	// Customizations c:
 	if (!splitscreen)
 	{
-		x += 18 + cv_stat_xoffset.value;
-		y += cv_stat_yoffset.value + (G_BattleGametype() ? (stplyr->kartstuff[k_bumper] ? -5 : -8) : 0) + spdoffset;
+		x += 18 + cv_stat_xoffset.value + spdxoffset;
+		y += cv_stat_yoffset.value + spdoffset;
 	}
 	else if (splitscreen == 1)	// I tried my best, but this is still mess :/ < :Blobcatpats: c:
 	{
 		x -= 10;
 		y -= 40;
-		y += (G_BattleGametype() ? (stplyr->kartstuff[k_bumper] ? -5 : -8) : 0);
+		y += spdoffset;
 
 		// If we are in 2-player splitscreen, for player 1 we move hud to up and remove snapping
 		// to bottom
@@ -9383,13 +9446,163 @@ static void K_drawKartLaps(void)
 	}
 }
 
+#ifdef ROTSPRITE
+
+#define DIALSPDDIV 97090 // 1.48148; converts 200 to 135
+
+static void K_DrawDialNum(INT32 x, INT32 y, boolean colorized, INT32 flags, INT32 num, INT32 digits, const UINT8 *colormap)
+{
+	INT32 w;
+
+	if (colorized)
+		w = SHORT(skp_dialnumclr[0]->width);
+	else
+		w = SHORT(skp_dialnum[0]->width);
+
+	if (flags & V_NOSCALESTART)
+		w *= vid.dupx;
+
+	if (num < 0)
+		num = -num;
+
+	// draw the number
+	do
+	{
+		x -= (w);
+
+		if (colorized)
+			V_DrawFixedPatch(x << FRACBITS, y << FRACBITS, FRACUNIT, flags, skp_dialnumclr[num % 10], colormap);
+		else
+			V_DrawFixedPatch(x << FRACBITS, y << FRACBITS, FRACUNIT, flags, skp_dialnum[num % 10], colormap);
+
+		num /= 10;
+	} while (--digits);
+}
+
+static void K_DrawDialLaps(INT32 x, INT32 y, INT32 num, INT32 total, INT32 flags)
+{
+	INT32 fx;
+	fx = x + ((num < 10) ? 0 : 6);
+	V_DrawRankNum(fx, y, flags, num, (num < 10) ? 1 : 2, NULL);
+	V_DrawScaledPatch(fx + 2, y, flags, frameslash);
+	V_DrawRankNum(fx + 13 + ((total < 10) ? 0 : 6), y, flags, total, (total < 10) ? 1 : 2, NULL);
+}
+
+static void K_DrawDialSpeedometer(fixed_t speed,
+								  INT32 splitflags,
+								  boolean battlemode,
+								  boolean infoactive,
+								  boolean colorized)
+{
+	UINT8* colormap = R_GetTranslationColormap(TC_DEFAULT, K_GetHudColor(), GTC_CACHE);
+
+	INT32 rot = 0;
+	UINT8 infoidx = (infoactive) ? 1 : 0;
+	patch_t* dialpatch;
+
+	angle_t speedangle =
+		FixedAngle(((FixedDiv(min(200 * FRACUNIT, speed), DIALSPDDIV) - (45 * FRACUNIT))));
+
+	rot = R_GetRollAngle(speedangle);
+
+	if (rot)
+	{
+		dialpatch = W_CachePatchNameRotated("K_DSDIAL", rot, PU_STATIC);
+	}
+	else
+	{
+		dialpatch = W_CachePatchName("K_DSDIAL", PU_STATIC);
+	}
+
+	if (colorized)  // Colourized hud
+	{
+		V_DrawMappedPatch(
+			SPDM_X, SPDM_Y - 9, (V_HUDTRANS | splitflags), skp_dialbaseclr[infoidx], colormap);
+		V_DrawMappedPatch(SPDM_X,
+						  SPDM_Y + 30,
+						  V_HUDTRANS | splitflags,
+						  skp_speedpatchesdialclr[cv_kartspeedometer.value],
+						  colormap);
+	}
+	else
+	{
+		V_DrawScaledPatch(SPDM_X, SPDM_Y - 9, (V_HUDTRANS | splitflags), skp_dialbase[infoidx]);
+		V_DrawScaledPatch(SPDM_X,
+						  SPDM_Y + 30,
+						  V_HUDTRANS | splitflags,
+						  skp_speedpatchesdial[cv_kartspeedometer.value]);
+	}
+
+	K_DrawDialNum(SPDM_X + 10,
+				  SPDM_Y + 25,
+				  colorized,
+				  V_HUDTRANS | splitflags,
+				  speed / FRACUNIT,
+				  3,
+				  colormap);
+
+	// gotta center the dial manually
+	V_DrawMappedPatch(SPDM_X - 19, SPDM_Y + 15, (V_HUDTRANS | splitflags), (dialpatch), colormap);
+
+	if (!infoactive)
+	{
+		// no need to draw info if we're not supposed to
+		return;
+	}
+
+	// draw the info
+	if (battlemode)
+	{
+		if (stplyr->kartstuff[k_bumper] <= 0)
+		{
+			V_DrawMappedPatch(
+				SPDM_X + 28, SPDM_Y + 27, V_HUDTRANS | splitflags, kp_splitkarmabomb, colormap);
+			K_DrawDialLaps(SPDM_X + 46,
+						   SPDM_Y + 29,
+						   stplyr->kartstuff[k_comebackpoints],
+						   2,
+						   V_HUDTRANS | splitflags);
+		}
+		else  // the above doesn't need to account for weird stuff since the max amount of karma
+			  // necessary is always 2 ^^^^
+		{
+			V_DrawMappedPatch(
+				SPDM_X + 28, SPDM_Y + 27, V_HUDTRANS | splitflags, kp_rankbumper, colormap);
+			K_DrawDialLaps(SPDM_X + 46,
+						   SPDM_Y + 29,
+						   stplyr->kartstuff[k_bumper],
+						   cv_kartbumpers.value,
+						   V_HUDTRANS | splitflags);
+		}
+	}
+	else
+	{
+		V_DrawScaledPatch(SPDM_X + 28, SPDM_Y + 27, V_HUDTRANS | splitflags, kp_splitlapflag);
+
+		if (stplyr->exiting)
+			V_DrawScaledPatch(SPDM_X + 39, SPDM_Y + 29, V_HUDTRANS | splitflags, skp_rankfinish);
+		else
+			K_DrawDialLaps(SPDM_X + 46,
+						   SPDM_Y + 29,
+						   stplyr->laps + 1,
+						   cv_numlaps.value,
+						   V_HUDTRANS | splitflags);
+	}
+}
+
+#undef DIALSPDDIV
+
+#endif
+
 static void K_drawKartSpeedometer(void)
 {
 	// why?
 	if (cv_kartspeedometer.value == 0)
 		return;
 
-	fixed_t convSpeed = 0;
+	// index 0 is the raw value, index 1 is the converted value
+	fixed_t convSpeed[2] = {0,0};
+
 	INT32 splitflags = K_calcSplitFlags(V_SNAPTOBOTTOM|V_SNAPTOLEFT);
 
 	// man.
@@ -9398,17 +9611,23 @@ static void K_drawKartSpeedometer(void)
 	switch (cv_kartspeedometer.value)
 	{
 		case 1:
-			convSpeed = FixedDiv(FixedMul(stplyr->speed, 142371), mapobjectscale)/FRACUNIT; // 2.172409058
+			convSpeed[0] = FixedDiv(FixedMul(stplyr->speed, 142371), mapobjectscale); // 2.172409058
+			convSpeed[1] = convSpeed[0] / FRACUNIT;
 			break;
 		case 2:
-			convSpeed = FixedDiv(FixedMul(stplyr->speed, 88465), mapobjectscale)/FRACUNIT; // 1.349868774
+			convSpeed[0] = FixedDiv(FixedMul(stplyr->speed, 88465), mapobjectscale); // 1.349868774
+			convSpeed[1] = convSpeed[0] / FRACUNIT;
 			break;
 		case 3:
-			convSpeed = FixedDiv(stplyr->speed, mapobjectscale)/FRACUNIT;
+			convSpeed[0] = FixedDiv(stplyr->speed, mapobjectscale);
+			convSpeed[1] = convSpeed[0] / FRACUNIT;
 			break;
 		case 4:
 			if (stplyr->mo)
-				convSpeed = (FixedDiv(stplyr->speed, FixedMul(K_GetKartSpeed(stplyr, false), ORIG_FRICTION))*100)>>FRACBITS;
+			{
+				convSpeed[0] = (FixedDiv(stplyr->speed, FixedMul(K_GetKartSpeed(stplyr, false), ORIG_FRICTION))*100);
+				convSpeed[1] = convSpeed[0] >> FRACBITS;
+			}
 			break;
 		default:
 			break;
@@ -9421,20 +9640,20 @@ static void K_drawKartSpeedometer(void)
 		switch (cv_kartspeedometer.value)
 		{
 			case 1:
-				metric = va("%3d km/h", convSpeed);
+				metric = va("%3d km/h", convSpeed[1]);
 				break;
 			case 2:
-				metric = va("%3d mph", convSpeed);
+				metric = va("%3d mph", convSpeed[1]);
 				break;
 			case 3:
-				metric = va("%3d fu/t", convSpeed);
+				metric = va("%3d fu/t", convSpeed[1]);
 				break;
 			case 4:
 				// if extra.kart is found, use its included % symbol
 				if (!xtra_speedo)
-					metric = va("%4d P", convSpeed);
+					metric = va("%4d P", convSpeed[1]);
 				else
-					metric = va("%4d %%", convSpeed);
+					metric = va("%4d %%", convSpeed[1]);
 			break;
 			default:
 				break;
@@ -9452,7 +9671,7 @@ static void K_drawKartSpeedometer(void)
 		else
 			V_DrawScaledPatch(SPDM_X + 1, SPDM_Y + 4, (V_HUDTRANS|splitflags), (skp_smallsticker));
 
-		V_DrawRankNum(SPDM_X + 26, SPDM_Y + 4, V_HUDTRANS|splitflags, convSpeed, 3, NULL);
+		V_DrawRankNum(SPDM_X + 26, SPDM_Y + 4, V_HUDTRANS|splitflags, convSpeed[1], 3, NULL);
 		V_DrawScaledPatch(SPDM_X + 31, SPDM_Y + 4, V_HUDTRANS|splitflags, skp_speedpatches[cv_kartspeedometer.value]);
 	}
 	else if (speedostyle == SPEEDO_ACHII) // why bother if we dont?
@@ -9461,16 +9680,26 @@ static void K_drawKartSpeedometer(void)
 		{
 			UINT8 *colormap = R_GetTranslationColormap(TC_DEFAULT, K_GetHudColor(), GTC_CACHE);
 			V_DrawMappedPatch(SPDM_X + 1, SPDM_Y + 4, (V_HUDTRANS|splitflags), (skp_smallstickerachiclr), colormap);
-			V_DrawRankNum(SPDM_X + 26, SPDM_Y + 4, V_HUDTRANS|splitflags, convSpeed, 3, NULL);
+			V_DrawRankNum(SPDM_X + 26, SPDM_Y + 4, V_HUDTRANS|splitflags, convSpeed[1], 3, NULL);
 			V_DrawMappedPatch(SPDM_X + 31, SPDM_Y + 4, V_HUDTRANS|splitflags, skp_speedpatchesachiclr[cv_kartspeedometer.value], colormap);
 		}
 		else
 		{
 			V_DrawScaledPatch(SPDM_X + 1, SPDM_Y + 4, (V_HUDTRANS|splitflags), (skp_smallstickerachi));
-			V_DrawRankNum(SPDM_X + 26, SPDM_Y + 4, V_HUDTRANS|splitflags, convSpeed, 3, NULL);
+			V_DrawRankNum(SPDM_X + 26, SPDM_Y + 4, V_HUDTRANS|splitflags, convSpeed[1], 3, NULL);
 			V_DrawScaledPatch(SPDM_X + 31, SPDM_Y + 4, V_HUDTRANS|splitflags, skp_speedpatchesachi[cv_kartspeedometer.value]);
 		}
 		}
+#ifdef ROTSPRITE
+	else if (speedostyle == SPEEDO_DIAL)  // why bother if we dont?
+	{
+		K_DrawDialSpeedometer(convSpeed[0],
+							splitflags,
+							(boolean)(G_BattleGametype()),
+							(LUA_HudEnabled(hud_gametypeinfo)),
+							(boolean)(K_UseColorHud() && dial_speedo_clr));
+	}
+#endif
 	else if (speedostyle == SPEEDO_EXTRA3) // why bother if we dont?
 	{
 		if (K_UseColorHud() && xtra_speedo_clr3) //Colourized hud
@@ -9481,7 +9710,7 @@ static void K_drawKartSpeedometer(void)
 		else
 			V_DrawStretchyFixedPatch((SPDM_X-1)<<FRACBITS, (SPDM_Y + 5)<<FRACBITS, FRACUNIT*0.765, FRACUNIT*0.55, (V_HUDTRANS|splitflags), (skp_smallsticker3), NULL, 0);
 
-		V_DrawRankNum(SPDM_X + 26, SPDM_Y + 4, V_HUDTRANS|splitflags, convSpeed, 3, NULL);
+		V_DrawRankNum(SPDM_X + 26, SPDM_Y + 4, V_HUDTRANS|splitflags, convSpeed[1], 3, NULL);
 		V_DrawScaledPatch(SPDM_X + 31, SPDM_Y + 4, V_HUDTRANS|splitflags, skp_speedpatches[cv_kartspeedometer.value]);
 	}
 	// Kart Z speedo bullshit...
@@ -11195,6 +11424,8 @@ void K_drawKartHUD(void)
 		return;
 	}
 
+	const UINT8 speedostyle = K_GetSpeedometerStyle();
+
 	battlefullscreen = ((G_BattleGametype())
 		&& (stplyr->exiting
 		|| (stplyr->kartstuff[k_bumper] <= 0
@@ -11324,7 +11555,7 @@ void K_drawKartHUD(void)
 		else if (G_RaceGametype()) // Race-only elements
 		{
 			// Draw the lap counter
-			if (LUA_HudEnabled(hud_gametypeinfo))
+			if ((LUA_HudEnabled(hud_gametypeinfo)) && ((!cv_kartspeedometer.value) || (speedostyle != SPEEDO_DIAL)))
 				K_drawKartLaps();
 
 			if (!splitscreen)
@@ -11347,7 +11578,7 @@ void K_drawKartHUD(void)
 		else if (G_BattleGametype()) // Battle-only
 		{
 			// Draw the hits left!
-			if (LUA_HudEnabled(hud_gametypeinfo))
+			if ((LUA_HudEnabled(hud_gametypeinfo)) && ((!cv_battlespeedo.value) || (speedostyle != SPEEDO_DIAL)))
 				K_drawKartBumpersOrKarma();
 
 			if ((!splitscreen) && cv_battlespeedo.value)

--- a/src/k_kart.h
+++ b/src/k_kart.h
@@ -40,7 +40,7 @@ extern consvar_t cv_battlespeedo;
 extern consvar_t cv_multiitemicon;
 extern consvar_t cv_huditemamount;
 
-#define NUMSPEEDOSTUFF 7
+#define NUMSPEEDOSTUFF 8
 extern CV_PossibleValue_t speedo_cons_t[NUMSPEEDOSTUFF];
 #define NUMDGAUGESTUFF 6
 extern CV_PossibleValue_t driftgaugestyle_cons_t[NUMDGAUGESTUFF];

--- a/src/m_menu.c
+++ b/src/m_menu.c
@@ -4925,7 +4925,7 @@ void M_Init(void)
 	}
 #endif
 
-	if (!xtra_speedo && !kartz_speedo && !achi_speedo) // why bother?
+	if (!xtra_speedo && !kartz_speedo && !achi_speedo && !dial_speedo) // why bother?
 		OP_SaturnHudMenu[sh_speedometer].status = IT_GRAYEDOUT;
 
 	//if (!xtra_speedo && kartz_speedo)


### PR DESCRIPTION
**WARNING: This fork is based on the Testing branch!** I'm aware that branch is very frequently updated, so it's likely my branch is already horrifically outdated... 😓 

This adds a dial-based speedometer as a HUD option. Makes for a neat showcase of the HUD rotation capabilities!
Due to how the speedometer itself is formatted, the lap/bumper counter is shrunken down when the dial speedometer is enabled.

![kart0000](https://github.com/user-attachments/assets/d96eba0d-a619-4180-b56b-87a787e010ba)
![kart0001](https://github.com/user-attachments/assets/a497ddba-6e0a-4e49-99ca-e93dd29eb2b9)

As per HUD graphic standards, this comes with both a non-colorized and colorized version. The extra.kart and extra2.kart files were modified to include the necessary graphics:
[extra_dialspeedometer.zip](https://github.com/user-attachments/files/19674396/extra_dialspeedometer.zip)

Very loose tests were done on a Windows build, with no notable issues.