### PR TITLE
Add a minimap headlight

### DIFF
--- a/src/d_main.c
+++ b/src/d_main.c
@@ -1222,6 +1222,7 @@ boolean driftgaugegfx = false;     // Driftgauge stuffs
 boolean multiitem_icon = false;    // Extra icons for Sneakers, Banana and Jawz
 boolean joystickicon = false;      // Extra icons for the joystick input display
 boolean minidoticon = false;        // Dot graphic for minimap player angle display
+boolean minilighticon = false;     // mkwii-style minimap headlight
 //
 
 static void IdentifyVersion(void)
@@ -1342,10 +1343,12 @@ static void D_CheckSaturnExtraFiles(void)
 	CV_PossibleValue_t speedo_cons_temp[NUMSPEEDOSTUFF] = {{1, "Default"}, {0, NULL}, {0, NULL}, {0, NULL}, {0, NULL}, {0, NULL}, {0, NULL}, {0, NULL}};
 	CV_PossibleValue_t driftgaugestyle_cons_temp[NUMDGAUGESTUFF] = {{1, "Default"}, {2, "Small"}, {3, "Big Numbers"}, {4, "Numbers Only"}, {0, NULL}, {0, NULL}};
 	CV_PossibleValue_t inputdisplay_cons_temp[NUMINPUTDISPLAYSTUFF] = {{0, "Off"}, {1, "Wheel"}, {2, "Stick"}, {0, NULL}, {0, NULL}};
+	CV_PossibleValue_t minimapdot_cons_temp[NUMMINIMAPDOTSTUFF] = {{0, "Off"}, {0, NULL}, {0, NULL}, {0, NULL}, {0, NULL}};
 
 	unsigned last_speedo_i = 0;
 	unsigned last_driftgauge_i = 3;
 	unsigned last_inputdisplay_i = 2;
+	unsigned last_minimapdot_i = 0;
 #define PUSHCONS(cons, i, id, name) { ++i; cons[i].value = id; cons[i].strvalue = name; }
 
 	// found the funny, add it in!
@@ -1438,6 +1441,13 @@ static void D_CheckSaturnExtraFiles(void)
 		if (W_LumpExists("MMAPDOT"))
 		{
 			minidoticon = true;
+			PUSHCONS(minimapdot_cons_temp, last_minimapdot_i, 1, "Dot");
+		}
+
+		if (W_LumpExists("MMAPHDLT"))
+		{
+			minilighticon = true;
+			PUSHCONS(minimapdot_cons_temp, last_minimapdot_i, 2, "Headlight");
 		}
 	}
 
@@ -1513,6 +1523,7 @@ static void D_CheckSaturnExtraFiles(void)
 	memcpy(speedo_cons_t, speedo_cons_temp, sizeof(speedo_cons_t));
 	memcpy(driftgaugestyle_cons_t, driftgaugestyle_cons_temp, sizeof(driftgaugestyle_cons_t));
 	memcpy(inputdisplay_cons_t, inputdisplay_cons_temp, sizeof(inputdisplay_cons_t));
+	memcpy(minimapdot_cons_t, minimapdot_cons_temp, sizeof(minimapdot_cons_t));
 }
 
 #include <locale.h>

--- a/src/d_main.h
+++ b/src/d_main.h
@@ -53,6 +53,7 @@ extern boolean driftgaugegfx;     // Driftgauge stuffs
 extern boolean multiitem_icon;    // Extra icons for Sneakers, Banana and Jawz
 extern boolean joystickicon;      // Extra icons for the joystick input display
 extern boolean minidoticon;       // Dot icon for minimap player angle display
+extern boolean minilighticon;     // mkwii-style minimap headlight
 //
 
 // autoload stuff

--- a/src/k_kart.c
+++ b/src/k_kart.c
@@ -10588,7 +10588,7 @@ static void K_drawKartPlayerCheck(void)
 	}
 }
 
-static void K_drawKartMinimapIcon(fixed_t objx, fixed_t objy, INT32 hudx, INT32 hudy, INT32 flags, INT32 blend, patch_t *icon, UINT8 *colormap, drawinfo_t *dims)
+static void K_drawKartMinimapIcon(fixed_t objx, fixed_t objy, INT32 hudx, INT32 hudy, INT32 flags, INT32 blend, patch_t *icon, UINT8 *colormap, drawinfo_t *dims, boolean scaleme)
 {
 	// amnum xpos & ypos are the icon's speed around the HUD.
 	// The number being divided by is for how fast it moves.
@@ -10623,19 +10623,19 @@ static void K_drawKartMinimapIcon(fixed_t objx, fixed_t objy, INT32 hudx, INT32 
 	}
 	else
 	{
-		w = SHORT(icon->width);
-		h = SHORT(icon->height);
+		w = icon->width;
+		h = icon->height;
 	}
 
-	amxpos = amnumxpos + ((hudx + (SHORT(AutomapPic->width)-w)/2)<<FRACBITS);
-	amypos = amnumypos + ((hudy + (SHORT(AutomapPic->height)-h)/2)<<FRACBITS);
+	amxpos = amnumxpos + ((hudx + (AutomapPic->width-w)/2)<<FRACBITS);
+	amypos = amnumypos + ((hudy + (AutomapPic->height-h)/2)<<FRACBITS);
 
-	/*if (cv_minihead.value && !(icon == kp_minimapdot))
+	if (cv_minihead.value && (scaleme))
 	{
-		amxpos += (icon->width / 4)<<FRACBITS;
-		amypos += (icon->height / 4)<<FRACBITS;
+		amxpos += (w / 4)<<FRACBITS;
+		amypos += (h / 4)<<FRACBITS;
 		scale /= 2;
-	}*/
+	}
 
 	V_DrawBlendingFixedPatch(amxpos, amypos, scale, flags, icon, colormap, blend);
 }
@@ -10911,7 +10911,8 @@ static void K_drawKartMinimap(void)
 					blending,
 					minipatch,
 					colormap,
-					&dims
+					&dims,
+					false
 			);
 		}
 

--- a/src/k_kart.c
+++ b/src/k_kart.c
@@ -106,7 +106,8 @@ consvar_t cv_fancyroulette = {"animatedroulette", "Off", CV_SAVE, CV_OnOff, NULL
 
 consvar_t cv_minihead = {"smallminimapplayers", "Off", CV_SAVE, CV_OnOff, NULL, 0, NULL, NULL, 0, 0, NULL};
 consvar_t cv_showminimapnames = {"showminimapnames", "Off", CV_SAVE, CV_OnOff, NULL, 0, NULL, NULL, 0, 0, NULL};
-consvar_t cv_showminimapangle = {"showminimapangle", "Off", CV_SAVE, CV_OnOff, NULL, 0, NULL, NULL, 0, 0, NULL};
+CV_PossibleValue_t minimapdot_cons_t[NUMMINIMAPDOTSTUFF];
+consvar_t cv_showminimapangle = {"showminimapangle", "Off", CV_SAVE, minimapdot_cons_t, NULL, 0, NULL, NULL, 0, 0, NULL};
 
 consvar_t cv_highresportrait = {"highresportrait", "Off", CV_SAVE, CV_OnOff, NULL, 0, NULL, NULL, 0, 0, NULL}; // make char potraits use their high-res version instead
 
@@ -10587,7 +10588,7 @@ static void K_drawKartPlayerCheck(void)
 	}
 }
 
-static void K_drawKartMinimapIcon(fixed_t objx, fixed_t objy, INT32 hudx, INT32 hudy, INT32 flags, patch_t *icon, UINT8 *colormap)
+static void K_drawKartMinimapIcon(fixed_t objx, fixed_t objy, INT32 hudx, INT32 hudy, INT32 flags, INT32 blend, patch_t *icon, UINT8 *colormap, drawinfo_t *dims)
 {
 	// amnum xpos & ypos are the icon's speed around the HUD.
 	// The number being divided by is for how fast it moves.
@@ -10600,6 +10601,7 @@ static void K_drawKartMinimapIcon(fixed_t objx, fixed_t objy, INT32 hudx, INT32 
 	INT32 amxpos, amypos;
 	fixed_t scale = FRACUNIT;
 	patch_t *AutomapPic;
+	INT16 w, h;
 
 	AutomapPic = minimapinfo.minimap_pic;
 
@@ -10614,17 +10616,28 @@ static void K_drawKartMinimapIcon(fixed_t objx, fixed_t objy, INT32 hudx, INT32 
 	if (encoremode)
 		amnumxpos = -amnumxpos;
 
-	amxpos = amnumxpos + ((hudx + (AutomapPic->width-icon->width)/2)<<FRACBITS);
-	amypos = amnumypos + ((hudy + (AutomapPic->height-icon->height)/2)<<FRACBITS);
+	if (dims && (dims->x != 0) && (dims->y != 0))
+	{
+		w = dims->x;
+		h = dims->y;
+	}
+	else
+	{
+		w = SHORT(icon->width);
+		h = SHORT(icon->height);
+	}
 
-	if (cv_minihead.value && !(icon == kp_minimapdot))
+	amxpos = amnumxpos + ((hudx + (SHORT(AutomapPic->width)-w)/2)<<FRACBITS);
+	amypos = amnumypos + ((hudy + (SHORT(AutomapPic->height)-h)/2)<<FRACBITS);
+
+	/*if (cv_minihead.value && !(icon == kp_minimapdot))
 	{
 		amxpos += (icon->width / 4)<<FRACBITS;
 		amypos += (icon->height / 4)<<FRACBITS;
 		scale /= 2;
-	}
+	}*/
 
-	V_DrawFixedPatch(amxpos, amypos, scale, flags, icon, colormap);
+	V_DrawBlendingFixedPatch(amxpos, amypos, scale, flags, icon, colormap, blend);
 }
 
 static void K_drawKartMinimapHead(mobj_t *mo, INT32 x, INT32 y, INT32 flags)
@@ -10713,6 +10726,13 @@ static void K_drawKartMinimapHead(mobj_t *mo, INT32 x, INT32 y, INT32 flags)
 		}
 	}
 }
+
+enum
+{
+	MINIANGLE_NONE = 0,
+	MINIANGLE_DOT,
+	MINIANGLE_LIGHT
+};
 
 static void K_drawKartMinimap(void)
 {
@@ -10828,6 +10848,9 @@ static void K_drawKartMinimap(void)
 	splitflags |= V_HUDTRANS;
 
 	const SINT8 icondotradius = (cv_minihead.value && !cv_showminimapnames.value) ? 8 : 10;
+	patch_t* minipatch;
+	INT32 rot;
+	INT32 blending;
 
 	for (i = 0; i < numlocalplayers; i++)
 	{
@@ -10836,37 +10859,64 @@ static void K_drawKartMinimap(void)
 
 		mobj_t *mobj = players[localplayers[i]].mo;
 
-		K_drawKartMinimapHead(mobj, x, y, splitflags);
-
-		if (!cv_showminimapangle.value || !minidoticon)
-			continue;
-
 		// dont draw for no contestants
-		if (mobj->health <= 0 && players[localplayers[i]].pflags & PF_TIMEOVER)
-			continue;
+		boolean playertimedout = (mobj->health <= 0 && players[localplayers[i]].pflags & PF_TIMEOVER);
 
-		UINT8 *colormap;
-		fixed_t interpx, interpy;
+		if (cv_showminimapangle.value && (minidoticon || minilighticon) && !playertimedout)
+		{
+			UINT8 *colormap;
+			drawinfo_t dims;
+			fixed_t interpx, interpy;
+			fixed_t xoff = 0, yoff = 0;
+			blending = 0;
 
-		angle_t ang = R_InterpolateAngle(mobj->old_angle, mobj->angle);
+			angle_t ang = R_InterpolateAngle(mobj->old_angle, mobj->angle);
 
-		if (mobj->colorized)
-			colormap = R_GetTranslationColormap(TC_RAINBOW, mobj->color, GTC_CACHE);
-		else
-			colormap = R_GetLocalTranslationColormap(mobj->skin, mobj->localskin, mobj->color, GTC_CACHE, mobj->skinlocal);
+			if (mobj->colorized)
+				colormap = R_GetTranslationColormap(TC_RAINBOW, mobj->color, GTC_CACHE);
+			else
+				colormap = R_GetLocalTranslationColormap(mobj->skin, mobj->localskin, mobj->color, GTC_CACHE, mobj->skinlocal);
 
-		interpx = lerp(mobj->old_x, mobj->x);
-		interpy = lerp(mobj->old_y, mobj->y);
+			interpx = lerp(mobj->old_x, mobj->x);
+			interpy = lerp(mobj->old_y, mobj->y);
 
-		K_drawKartMinimapIcon(
-				interpx,
-				interpy,
-				x + FixedMul(FCOS(ang), icondotradius),
-				y - FixedMul(FSIN(ang), icondotradius),
-				splitflags,
-				kp_minimapdot,
-				colormap
-		);
+			minipatch = kp_minimapdot;
+
+			dims.x = 0;
+			dims.y = 0;
+
+			if (cv_showminimapangle.value == MINIANGLE_DOT)
+			{
+				xoff = FixedMul(FCOS(ang), icondotradius);
+				yoff = -FixedMul(FSIN(ang), icondotradius);
+			}
+			else if (cv_showminimapangle.value == MINIANGLE_LIGHT)
+			{
+				rot = R_GetRollAngle(ang);
+				minipatch = W_CachePatchNameRotated("MMAPHDLT", rot, PU_PATCH);
+
+				blending = B_ADD;
+				xoff = yoff = 0;
+
+				dims.x = 48;
+				dims.y = 24;
+			}
+
+			K_drawKartMinimapIcon(
+					interpx,
+					interpy,
+					x + xoff,
+					y + yoff,
+					splitflags,
+					blending,
+					minipatch,
+					colormap,
+					&dims
+			);
+		}
+
+		// draw the minimap head after the nonsense above
+		K_drawKartMinimapHead(mobj, x, y, splitflags);
 	}
 }
 

--- a/src/k_kart.h
+++ b/src/k_kart.h
@@ -47,6 +47,9 @@ extern CV_PossibleValue_t speedo_cons_t[NUMSPEEDOSTUFF];
 extern CV_PossibleValue_t driftgaugestyle_cons_t[NUMDGAUGESTUFF];
 #define NUMINPUTDISPLAYSTUFF 5
 extern CV_PossibleValue_t inputdisplay_cons_t[NUMINPUTDISPLAYSTUFF];
+#define NUMMINIMAPDOTSTUFF 5
+extern CV_PossibleValue_t minimapdot_cons_t[NUMMINIMAPDOTSTUFF];
+
 
 boolean K_IsPlayerLosing(player_t *player);
 boolean K_IsPlayerWanted(player_t *player);

--- a/src/m_menu.c
+++ b/src/m_menu.c
@@ -2453,7 +2453,7 @@ static menuitem_t OP_SaturnHudMenu[] =
 	{IT_STRING | IT_CVAR, NULL,	"Show Names on Minimap",   				&cv_showminimapnames, 		135},
 	{IT_STRING | IT_CVAR, NULL,	"Small Minimap Players",   				&cv_minihead, 				140},
 	{IT_STRING | IT_CVAR, NULL,	"Spin Minimap Icons", 			  		&cv_spinoutroll,      		145},
-	{IT_STRING | IT_CVAR, NULL,	"Player Angle Dot", 			  		&cv_showminimapangle,      	150},
+	{IT_STRING | IT_CVAR, NULL,	"Player Angle Visual", 			  		&cv_showminimapangle,      	150},
 
 	{IT_STRING | IT_CVAR, NULL, "Beta Intermissionscreen", 				&cv_betainterscreen, 		160},
 
@@ -2487,7 +2487,7 @@ static const char* OP_SaturnHudTooltips[] =
 	"Show player names on the minimap.",
 	"Minimize the player icons on the minimap.",
 	"Erratically rotate player icons during spinouts.",
-	"Show a dot showing the player facing angle.",
+	"Visualize the player facing angle.",
 	"Make the Intermission screen look like in beta versions of Kart!\nEither with background or just the rest.",
 	"Show the Director Toggle prompt when spectating.",
 	"Nametag Options.",
@@ -4969,7 +4969,7 @@ void M_Init(void)
 	if (!nametaggfx)
 		OP_NametagMenu[nt_ntchar].status = IT_GRAYEDOUT;
 
-	if (!minidoticon)
+	if (!minidoticon && !minilighticon)
 		OP_SaturnHudMenu[sh_minidot].status = IT_GRAYEDOUT;
 
 #ifndef NONET


### PR DESCRIPTION
what the title says: adds the "headlight" visual from mario kart wii as a selectable option in the saturn HUD menu, while also renaming "player angle dot" to "player angle visual"
![kart0009](https://github.com/user-attachments/assets/4e14c396-d453-4b30-9df6-68e53065b025)
![kart0006](https://github.com/user-attachments/assets/e020e725-6047-45f0-994d-17bfd3e38f28)![kart0007](https://github.com/user-attachments/assets/d22cb239-64ef-4d3f-a121-e74b9722de52)

like the speedometer types, the angle visualizer types are allocated the same way now, and handled as such
they are also drawn _behind_ the player's icon, so the relevant drawing code had to be refactored as well
![kart0014](https://github.com/user-attachments/assets/5de08d0b-3c72-46cd-b758-d1a900fbf73f)
![kart0015](https://github.com/user-attachments/assets/4c5d1e9f-2b1d-4ea7-9f2f-246d96fe8c9e)

[.zip file containing the .lmp that goes with this](https://github.com/user-attachments/files/19967061/MMAPHDLT.zip); put it in extra.kart for the game to detect it

