### PR TITLE
Add interpolation related stats to perfstats

### DIFF
--- a/src/d_main.c
+++ b/src/d_main.c
@@ -827,6 +827,11 @@ void D_SRB2Loop(void)
 		{
 			renderdeltatics = FloatToFixed(deltatics);
 
+			// I looked at the possibility of putting in a float drawer for
+			// perfstats and it's very complicated, so we'll just do this instead...
+			ps_interp_frac.value.p = (precise_t)((FIXED_TO_FLOAT(g_time.timefrac)) * 1000.0f);
+			ps_interp_lag.value.p = (precise_t)((deltasecs) * 1000.0f);
+
 			if (!(paused || P_AutoPause()) && deltatics < 1.0 && !hu_stopped)
 			{
 				rendertimefrac = g_time.timefrac;

--- a/src/m_perfstats.c
+++ b/src/m_perfstats.c
@@ -127,8 +127,8 @@ perfstatrow_t commoncounter_rows[] = {
 };
 
 perfstatrow_t interpolation_rows[] = {
-	{"intpfrc", "Interp frac: ", &ps_interp_frac, PS_TIME},
-	{"intplag", "Interp lag:  ", &ps_interp_lag, PS_TIME},
+	{"intpfrc", "Interp frac: ", &ps_interp_frac, 0},
+	{"intplag", "Interp lag:  ", &ps_interp_lag, 0},
 	{0}
 };
 
@@ -784,7 +784,7 @@ static void PS_DrawRenderStats(void)
 	if (PS_IsLevelActive())
 	{
 		x = hires ? 115 : 90;
-		cy = PS_DrawPerfRows(x, 10, V_BLUEMAP, commoncounter_rows);// + half_row;
+		cy = PS_DrawPerfRows(x, 10, V_BLUEMAP, commoncounter_rows) + half_row;
 
 #ifdef HWRENDER
 		if (rendermode == render_opengl && cv_glbatching.value)

--- a/src/m_perfstats.c
+++ b/src/m_perfstats.c
@@ -126,11 +126,11 @@ perfstatrow_t commoncounter_rows[] = {
 	{0}
 };
 
-/*perfstatrow_t interpolation_rows[] = {
+perfstatrow_t interpolation_rows[] = {
 	{"intpfrc", "Interp frac: ", &ps_interp_frac, PS_TIME},
 	{"intplag", "Interp lag:  ", &ps_interp_lag, PS_TIME},
 	{0}
-};*/
+};
 
 #ifdef HWRENDER
 perfstatrow_t batchcount_rows[] = {
@@ -553,8 +553,8 @@ static void PS_UpdateFrameStats(void)
 		if (PS_IsLevelActive())
 			PS_UpdateRowHistories(commoncounter_rows, true);
 
-		/*if (R_UsingFrameInterpolation())
-			PS_UpdateRowHistories(interpolation_rows, true);*/
+		if (R_UsingFrameInterpolation())
+			PS_UpdateRowHistories(interpolation_rows, true);
 
 #ifdef HWRENDER
 		if (rendermode == render_opengl && cv_glbatching.value)
@@ -773,7 +773,7 @@ static void PS_DrawRenderStats(void)
 {
 	const boolean hires = PS_HighResolution();
 	const int half_row = hires ? 5 : 4;
-	int x, y = 10; //, cy = 10;
+	int x, y, cy = 10;
 
 	PS_DrawDescriptorHeader();
 
@@ -784,7 +784,7 @@ static void PS_DrawRenderStats(void)
 	if (PS_IsLevelActive())
 	{
 		x = hires ? 115 : 90;
-		/*cy = */PS_DrawPerfRows(x, 10, V_BLUEMAP, commoncounter_rows);// + half_row;
+		cy = PS_DrawPerfRows(x, 10, V_BLUEMAP, commoncounter_rows);// + half_row;
 
 #ifdef HWRENDER
 		if (rendermode == render_opengl && cv_glbatching.value)
@@ -799,11 +799,11 @@ static void PS_DrawRenderStats(void)
 #endif
 	}
 
-	/*if (R_UsingFrameInterpolation())
+	if (R_UsingFrameInterpolation())
 	{
 		x = hires ? 115 : 90;
-		PS_DrawPerfRows(x, cy, V_ROSYMAP, interpolation_rows);
-	}*/
+		PS_DrawPerfRows(x, cy, V_PEACHMAP, interpolation_rows);
+	}
 }
 
 static void PS_DrawGameLogicStats(void)

--- a/src/r_fps.c
+++ b/src/r_fps.c
@@ -45,6 +45,9 @@ consvar_t cv_fpscap = {"fpscap", "Match refresh rate", CV_SAVE, fpscap_cons_t, N
 
 consvar_t cv_precipinterp = {"precipinterpolation", "On", CV_SAVE, CV_OnOff, NULL, 0, NULL, NULL, 0, 0, NULL};
 
+ps_metric_t ps_interp_frac = {0};
+ps_metric_t ps_interp_lag = {0};
+
 UINT32 R_GetFramerateCap(void)
 {
 	if (rendermode == render_none)

--- a/src/r_fps.h
+++ b/src/r_fps.h
@@ -18,9 +18,13 @@
 #include "m_fixed.h"
 #include "p_local.h"
 #include "r_state.h"
+#include "m_perfstats.h"
 
 extern consvar_t cv_fpscap;
 extern consvar_t cv_precipinterp;
+
+extern ps_metric_t ps_interp_frac;
+extern ps_metric_t ps_interp_lag;
 
 UINT32 R_GetFramerateCap(void);
 boolean R_UsingFrameInterpolation(void);


### PR DESCRIPTION
Adds the interp frac and interp lag stats to perfstats 1, which were missing from the Kart port of perfstats for some reason.
![kart0001](https://github.com/user-attachments/assets/3a87ea89-22a3-4be0-8613-245ab9eca7bb)

