### PR TITLE
Better Vote Background scaling behaviour

### DIFF
--- a/src/m_menu.c
+++ b/src/m_menu.c
@@ -1555,15 +1555,17 @@ static menuitem_t OP_ExpOptionsMenu[] =
 
 	{IT_STRING | IT_CVAR,	NULL, "FPS counter sampling",			&cv_accuratefps,			 50},
 
+	{IT_STRING | IT_CVAR,	NULL, "Votescreen Scaling",				&cv_votebgscaling,			 60},
+
 #ifdef HWRENDER
-	{IT_STRING | IT_CVAR, 	NULL, "Screen Textures", 				&cv_glscreentextures, 		 60},
+	{IT_STRING | IT_CVAR, 	NULL, "Screen Textures", 				&cv_glscreentextures, 		 70},
 #ifdef USE_FBO_OGL
-	{IT_STRING | IT_CVAR, 	NULL, "FBO Downsampling support", 		&cv_glframebuffer, 			 65},
-	{IT_STRING | IT_CVAR, 	NULL, "Palette Depth", 					&cv_glpalettedepth, 		 75},
-	{IT_DISABLED, 			NULL, "", 								NULL,     			 		 85},	// dummy text
+	{IT_STRING | IT_CVAR, 	NULL, "FBO Downsampling support", 		&cv_glframebuffer, 			 75},
+	{IT_STRING | IT_CVAR, 	NULL, "Palette Depth", 					&cv_glpalettedepth, 		 85},
+	{IT_DISABLED, 			NULL, "", 								NULL,     			 		 95},	// dummy text
 #else
-	{IT_STRING | IT_CVAR, 	NULL, "Palette Depth", 					&cv_glpalettedepth, 		 70},
-	{IT_DISABLED, 			NULL, "", 								NULL,     			 		 80},	// dummy text
+	{IT_STRING | IT_CVAR, 	NULL, "Palette Depth", 					&cv_glpalettedepth, 		 80},
+	{IT_DISABLED, 			NULL, "", 								NULL,     			 		 90},	// dummy text
 #endif
 #endif
 };
@@ -1578,6 +1580,7 @@ static const char* OP_ExpTooltips[] =
 	//"Should the directional lightning be randomized each map?\nTakes effect on next map load.",
 	"Toggle being able to see the sky.",
 	"Change the FPS counter sampling method\nInaccurate updates slower and might miss frame drops and such\nAccurate updates faster and is more accurate, but might be less readable", // how to ingles??
+	"Different methods of scaling the votescreen backgrounds.",
 #ifdef HWRENDER
 	"Should the game do Screen Textures? Provides a good boost to frames\nat the cost of some visual effects not working when disabled.",
 #ifdef USE_FBO_OGL

--- a/src/screen.c
+++ b/src/screen.c
@@ -65,6 +65,9 @@ consvar_t cv_renderview = {"renderview", "On", 0, CV_OnOff, NULL, 0, NULL, NULL,
 consvar_t cv_vhseffect = {"vhspause", "On", CV_SAVE, CV_OnOff, NULL, 0, NULL, NULL, 0, 0, NULL};
 consvar_t cv_shittyscreen = {"televisionsignal", "Okay", CV_NOSHOWHELP, shittyscreen_cons_t, NULL, 0, NULL, NULL, 0, 0, NULL};
 
+static CV_PossibleValue_t votescale_cons_t[] = {{0, "Vanilla"}, {1, "Adaptive"}, {1, "VerticalFill"}, {1, "HorizontalFill"}, {0, NULL}};
+consvar_t cv_votebgscaling = {"votebgscaling", "Adaptive", CV_SAVE, votescale_cons_t, NULL, 0, NULL, NULL, 0, 0, NULL};
+
 static void Highreshudscale_OnChange(void);
 static CV_PossibleValue_t highreshudscale_cons_t[] = {{4*FRACUNIT/5, "MIN"}, {6*FRACUNIT/5, "MAX"}, {0, NULL}};
 consvar_t cv_highreshudscale = {"highreshudscale", "1", CV_SAVE|CV_FLOAT|CV_CALL|CV_NOINIT|CV_NOSHOWHELP, highreshudscale_cons_t, Highreshudscale_OnChange, 0, NULL, NULL, 0, 0, NULL};
@@ -215,6 +218,8 @@ void SCR_Startup(void)
 	CV_RegisterVar(&cv_csaturation);
 	CV_RegisterVar(&cv_bsaturation);
 	CV_RegisterVar(&cv_msaturation);
+
+	CV_RegisterVar(&cv_votebgscaling);
 
 	V_SetPalette(0);
 }

--- a/src/screen.c
+++ b/src/screen.c
@@ -65,7 +65,7 @@ consvar_t cv_renderview = {"renderview", "On", 0, CV_OnOff, NULL, 0, NULL, NULL,
 consvar_t cv_vhseffect = {"vhspause", "On", CV_SAVE, CV_OnOff, NULL, 0, NULL, NULL, 0, 0, NULL};
 consvar_t cv_shittyscreen = {"televisionsignal", "Okay", CV_NOSHOWHELP, shittyscreen_cons_t, NULL, 0, NULL, NULL, 0, 0, NULL};
 
-static CV_PossibleValue_t votescale_cons_t[] = {{0, "Vanilla"}, {1, "Adaptive"}, {1, "VerticalFill"}, {1, "HorizontalFill"}, {0, NULL}};
+static CV_PossibleValue_t votescale_cons_t[] = {{0, "Vanilla"}, {1, "Adaptive"}, {2, "VerticalFill"}, {3, "HorizontalFill"}, {0, NULL}};
 consvar_t cv_votebgscaling = {"votebgscaling", "Adaptive", CV_SAVE, votescale_cons_t, NULL, 0, NULL, NULL, 0, 0, NULL};
 
 static void Highreshudscale_OnChange(void);

--- a/src/screen.h
+++ b/src/screen.h
@@ -153,6 +153,8 @@ extern consvar_t cv_timescale;
 
 extern consvar_t cv_alwaysgrabmouse;
 
+extern consvar_t cv_votebgscaling;
+
 // quick fix for tall/short skies, depending on bytesperpixel
 extern void (*walldrawerfunc)(void);
 

--- a/src/v_video.c
+++ b/src/v_video.c
@@ -1562,37 +1562,12 @@ void V_DrawPatchFill(patch_t *pat)
 	}
 }
 
-// Draws a patch and scales it to fill out the screen vertically while remaining centered
-/*void V_DrawCenteredScaledFullScreenPatch(patch_t *patch)
-{
-	fixed_t scale = FixedDiv(vid.height << FRACBITS, patch->height << FRACBITS);
-	fixed_t x = ((vid.width << FRACBITS) - FixedMul(patch->width << FRACBITS, scale)) / 2; // i fucking hate maths
-	V_DrawFixedPatch(x, 0, scale, V_NOSCALEPATCH, patch, NULL);
-}
-
-void V_DrawCenteredScaledFullScreenPatch(patch_t *patch)
-{
-	fixed_t scale = FixedDiv(vid.width << FRACBITS, patch->width << FRACBITS);
-
-	fixed_t scaled_height = FixedMul(patch->height << FRACBITS, scale);
-
-	fixed_t y = (vid.height << FRACBITS) - scaled_height;
-
-	if (scaled_height < (vid.height << FRACBITS))
-	{
-		y /= 2;
-	}
-
-	V_DrawFixedPatch(0, y, scale, V_NOSCALEPATCH, patch, NULL);
-}*/
-
-void V_DrawCenteredScaledFullScreenPatch(patch_t *patch)
+// Draws a patch and tries to always fill the screen with the patch
+void V_DrawAdaptiveScaledFullScreenPatch(patch_t *patch)
 {
 	fixed_t x = 0, y = 0, scale = FRACUNIT;
 
-	//scale = FixedDiv(vid.width << FRACBITS, patch->width << FRACBITS); // fit the screen horizontally
 	scale = ((vid.width * FRACUNIT) / patch->width); // fit the screen horizontally
-
 
 	fixed_t scaled_height = FixedMul(patch->height << FRACBITS, scale);
 
@@ -1606,6 +1581,33 @@ void V_DrawCenteredScaledFullScreenPatch(patch_t *patch)
 		y = (vid.height << FRACBITS) - scaled_height;
 
 	V_DrawFixedPatch(x, y, scale, V_NOSCALEPATCH, patch, NULL);
+}
+
+// Draws a patch and scales it to fill out the screen vertically while remaining centered
+void V_DrawVerticallyScaledFullScreenPatch(patch_t *patch)
+{
+	fixed_t scale = ((vid.height * FRACUNIT) / patch->height);
+	fixed_t x = ((vid.width << FRACBITS) - FixedMul(patch->width << FRACBITS, scale)) / 2; // i fucking hate maths
+	V_DrawFixedPatch(x, 0, scale, V_NOSCALEPATCH, patch, NULL);
+}
+
+// Draws a patch and scales it to fill out the screen horizontally
+// centers the patch when its too small to fit the screen vertically
+void V_DrawHorizontallyScaledFullScreenPatch(patch_t *patch)
+{
+	fixed_t scale = ((vid.width * FRACUNIT) / patch->width);
+
+	fixed_t scaled_height = FixedMul(patch->height << FRACBITS, scale);
+
+	fixed_t y = (vid.height << FRACBITS) - scaled_height;
+
+	// center it if it does not fit the screen vertically
+	if (scaled_height < (vid.height << FRACBITS))
+	{
+		y /= 2;
+	}
+
+	V_DrawFixedPatch(0, y, scale, V_NOSCALEPATCH, patch, NULL);
 }
 
 void V_DrawVhsEffect(boolean rewind)

--- a/src/v_video.c
+++ b/src/v_video.c
@@ -1563,11 +1563,49 @@ void V_DrawPatchFill(patch_t *pat)
 }
 
 // Draws a patch and scales it to fill out the screen vertically while remaining centered
-void V_DrawCenteredScaledFullScreenPatch(patch_t *patch)
+/*void V_DrawCenteredScaledFullScreenPatch(patch_t *patch)
 {
 	fixed_t scale = FixedDiv(vid.height << FRACBITS, patch->height << FRACBITS);
 	fixed_t x = ((vid.width << FRACBITS) - FixedMul(patch->width << FRACBITS, scale)) / 2; // i fucking hate maths
 	V_DrawFixedPatch(x, 0, scale, V_NOSCALEPATCH, patch, NULL);
+}
+
+void V_DrawCenteredScaledFullScreenPatch(patch_t *patch)
+{
+	fixed_t scale = FixedDiv(vid.width << FRACBITS, patch->width << FRACBITS);
+
+	fixed_t scaled_height = FixedMul(patch->height << FRACBITS, scale);
+
+	fixed_t y = (vid.height << FRACBITS) - scaled_height;
+
+	if (scaled_height < (vid.height << FRACBITS))
+	{
+		y /= 2;
+	}
+
+	V_DrawFixedPatch(0, y, scale, V_NOSCALEPATCH, patch, NULL);
+}*/
+
+void V_DrawCenteredScaledFullScreenPatch(patch_t *patch)
+{
+	fixed_t x = 0, y = 0, scale = FRACUNIT;
+
+	//scale = FixedDiv(vid.width << FRACBITS, patch->width << FRACBITS); // fit the screen horizontally
+	scale = ((vid.width * FRACUNIT) / patch->width); // fit the screen horizontally
+
+
+	fixed_t scaled_height = FixedMul(patch->height << FRACBITS, scale);
+
+	// however, if this means the patch doesent fill out the screen vertically then
+	if (scaled_height < (vid.height << FRACBITS))
+	{
+		scale = ((vid.height * FRACUNIT) / patch->height); // scale it to fit the screen vertically
+		x = ((vid.width << FRACBITS) - FixedMul(patch->width << FRACBITS, scale)) / 2;
+	}
+	else
+		y = (vid.height << FRACBITS) - scaled_height;
+
+	V_DrawFixedPatch(x, y, scale, V_NOSCALEPATCH, patch, NULL);
 }
 
 void V_DrawVhsEffect(boolean rewind)

--- a/src/v_video.c
+++ b/src/v_video.c
@@ -1565,10 +1565,8 @@ void V_DrawPatchFill(patch_t *pat)
 // Draws a patch and tries to always fill the screen with the patch
 void V_DrawAdaptiveScaledFullScreenPatch(patch_t *patch)
 {
-	fixed_t x = 0, y = 0, scale = FRACUNIT;
-
-	scale = ((vid.width * FRACUNIT) / patch->width); // fit the screen horizontally
-
+	fixed_t x = 0, y = 0;
+	fixed_t scale = ((vid.width * FRACUNIT) / patch->width); // fit the screen horizontally
 	fixed_t scaled_height = FixedMul(patch->height << FRACBITS, scale);
 
 	// however, if this means the patch doesent fill out the screen vertically then
@@ -1588,6 +1586,7 @@ void V_DrawVerticallyScaledFullScreenPatch(patch_t *patch)
 {
 	fixed_t scale = ((vid.height * FRACUNIT) / patch->height);
 	fixed_t x = ((vid.width << FRACBITS) - FixedMul(patch->width << FRACBITS, scale)) / 2; // i fucking hate maths
+
 	V_DrawFixedPatch(x, 0, scale, V_NOSCALEPATCH, patch, NULL);
 }
 
@@ -1596,9 +1595,7 @@ void V_DrawVerticallyScaledFullScreenPatch(patch_t *patch)
 void V_DrawHorizontallyScaledFullScreenPatch(patch_t *patch)
 {
 	fixed_t scale = ((vid.width * FRACUNIT) / patch->width);
-
 	fixed_t scaled_height = FixedMul(patch->height << FRACBITS, scale);
-
 	fixed_t y = (vid.height << FRACBITS) - scaled_height;
 
 	// center it if it does not fit the screen vertically

--- a/src/v_video.c
+++ b/src/v_video.c
@@ -1562,6 +1562,14 @@ void V_DrawPatchFill(patch_t *pat)
 	}
 }
 
+// Draws a patch and scales it to fill out the screen vertically while remaining centered
+void V_DrawCenteredScaledFullScreenPatch(patch_t *patch)
+{
+	fixed_t scale = FixedDiv(vid.height << FRACBITS, patch->height << FRACBITS);
+	fixed_t x = ((vid.width << FRACBITS) - FixedMul(patch->width << FRACBITS, scale)) / 2; // i fucking hate maths
+	V_DrawFixedPatch(x, 0, scale, V_NOSCALEPATCH, patch, NULL);
+}
+
 void V_DrawVhsEffect(boolean rewind)
 {
 	static fixed_t upbary = 100*FRACUNIT, downbary = 150*FRACUNIT;

--- a/src/v_video.h
+++ b/src/v_video.h
@@ -282,6 +282,7 @@ typedef struct player_s player_t;
 void V_DoPostProcessor(INT32 view, INT32 param);
 
 void V_DrawPatchFill(patch_t *pat);
+void V_DrawCenteredScaledFullScreenPatch(patch_t *patch);
 
 void VID_BlitLinearScreen(const UINT8 *srcptr, UINT8 *destptr, INT32 width, INT32 height, size_t srcrowbytes,
 	size_t destrowbytes);

--- a/src/v_video.h
+++ b/src/v_video.h
@@ -282,7 +282,10 @@ typedef struct player_s player_t;
 void V_DoPostProcessor(INT32 view, INT32 param);
 
 void V_DrawPatchFill(patch_t *pat);
-void V_DrawCenteredScaledFullScreenPatch(patch_t *patch);
+
+void V_DrawAdaptiveScaledFullScreenPatch(patch_t *patch);
+void V_DrawVerticallyScaledFullScreenPatch(patch_t *patch);
+void V_DrawHorizontallyScaledFullScreenPatch(patch_t *patch);
 
 void VID_BlitLinearScreen(const UINT8 *srcptr, UINT8 *destptr, INT32 width, INT32 height, size_t srcrowbytes,
 	size_t destrowbytes);

--- a/src/y_inter.c
+++ b/src/y_inter.c
@@ -906,6 +906,28 @@ static void Y_UnloadData(void)
 
 // SRB2Kart: Voting!
 
+static void Y_DrawVoteBackground(patch_t *patch)
+{
+	switch (cv_votebgscaling.value)
+	{
+		case 1: // adaptive
+			V_DrawAdaptiveScaledFullScreenPatch(patch);
+			break;
+		case 2: // vertical-fill
+			V_DrawVerticallyScaledFullScreenPatch(patch);
+			break;
+		case 3: // horizontal-fill
+			V_DrawHorizontallyScaledFullScreenPatch(patch);
+			break;
+		case 0: // vanilla
+		default:
+			V_DrawScaledPatch(((vid.width/2) / vid.dupx) - (patch->width/2),
+							  (vid.height / vid.dupy) - patch->height,
+							  V_SNAPTOTOP|V_SNAPTOLEFT, patch);
+			break;
+	}
+}
+
 // Y_DrawAnimatedVoteScreenPatch
 //
 // Draw animated patch based on frame counter on vote screen
@@ -923,7 +945,7 @@ static void Y_DrawAnimatedVoteScreenPatch(boolean widePatch)
 
 	votebg = W_CachePatchName(va("%s%d", tempAnimPrefix, currentAnimFrame + 1), PU_PATCH);
 
-	V_DrawCenteredScaledFullScreenPatch(votebg);
+	Y_DrawVoteBackground(votebg);
 
 	if (renderisnewtic && (votetic % 2 == 0) && !paused)
 		currentAnimFrame = (currentAnimFrame + 1 > tempFoundAnimVoteFrames) ? 0 : (currentAnimFrame + 1);
@@ -952,7 +974,7 @@ static void Y_DrawVoteScreenPatch(void)
 		votebg = widebgpatch;
 	}
 
-	V_DrawCenteredScaledFullScreenPatch(votebg);
+	Y_DrawVoteBackground(votebg);
 }
 
 //

--- a/src/y_inter.c
+++ b/src/y_inter.c
@@ -294,27 +294,23 @@ static void Y_CalculateMatchData(UINT8 rankingsmode, void (*comparison)(INT32))
 static void Y_AnimatedVoteScreenCheck(void)
 {
 	char tmpPrefix[] = "INTS";
-	boolean stopSearching = false;
 
 	if (luaVoteScreen)
 		strncpy(tmpPrefix, luaVoteScreen, 4);
-	else
-	{
-		if (G_BattleGametype())
-			strcpy(tmpPrefix, "BTLS");
-	}
+	else if (G_BattleGametype())
+		strcpy(tmpPrefix, "BTLS");
 
 	strncpy(animPrefix, tmpPrefix, 4);
 	animPrefix[4] = 'C';
 	strncpy(animWidePrefix, tmpPrefix, 4);
 	animWidePrefix[4] = 'W';
 
-	foundAnimVoteFrames = 0;
-	foundAnimVoteWideFrames = 0;
+	foundAnimVoteFrames = foundAnimVoteWideFrames = 0;
 	currentAnimFrame = 0;
 
 	INT32 i = 1;
-	while (!stopSearching)
+
+	for (;;)
 	{
 		boolean normalLumpExists = W_LumpExists(va("%sC%d", tmpPrefix, i));
 		boolean wideLumpExists = W_LumpExists(va("%sW%d", tmpPrefix, i));
@@ -328,7 +324,7 @@ static void Y_AnimatedVoteScreenCheck(void)
 				foundAnimVoteWideFrames++;
 		}
 		else // If we don't find at least frame 1 (e.g VEXTRN1), let's just stop looking
-			stopSearching = true;
+			break;
 
 		i++;
 	}

--- a/src/y_inter.c
+++ b/src/y_inter.c
@@ -934,21 +934,25 @@ static void Y_DrawVoteBackground(patch_t *patch)
 //
 static void Y_DrawAnimatedVoteScreenPatch(boolean widePatch)
 {
+	INT32 nextframe = 0;
 	patch_t *votebg = NULL;
 	char tempAnimPrefix[7];
+	const INT32 tempFoundAnimVoteFrames = ((widePatch ? foundAnimVoteWideFrames : foundAnimVoteFrames) - 1);
+
 	strcpy(tempAnimPrefix, (widePatch ? animWidePrefix : animPrefix));
-	const INT32 tempFoundAnimVoteFrames = (widePatch ? foundAnimVoteWideFrames : foundAnimVoteFrames) - 1;
 
 	// Just in case someone provides LESS widescreen frames than normal frames or vice versa, reset the frame counter to 0
 	if (currentAnimFrame > tempFoundAnimVoteFrames)
 		currentAnimFrame = 0;
 
-	votebg = W_CachePatchName(va("%s%d", tempAnimPrefix, currentAnimFrame + 1), PU_PATCH);
+	nextframe = (currentAnimFrame + 1);
+
+	votebg = W_CachePatchName(va("%s%d", (widePatch ? animWidePrefix : animPrefix), nextframe), PU_PATCH);
 
 	Y_DrawVoteBackground(votebg);
 
 	if (renderisnewtic && (votetic % 2 == 0) && !paused)
-		currentAnimFrame = (currentAnimFrame + 1 > tempFoundAnimVoteFrames) ? 0 : (currentAnimFrame + 1);
+		currentAnimFrame = (nextframe > tempFoundAnimVoteFrames) ? 0 : nextframe;
 }
 
 static void Y_DrawVoteScreenPatch(void)
@@ -1027,6 +1031,7 @@ void Y_VoteDrawer(void)
 	}
 
 	y = (200-height)/2;
+
 	for (i = 0; i < 4; i++)
 	{
 		const char *str;

--- a/src/y_inter.c
+++ b/src/y_inter.c
@@ -912,35 +912,35 @@ static void Y_UnloadData(void)
 //
 static void Y_DrawAnimatedVoteScreenPatch(boolean widePatch)
 {
+	patch_t *votebg = NULL;
 	char tempAnimPrefix[7];
-	widePatch ? strcpy(tempAnimPrefix, animWidePrefix) : strcpy(tempAnimPrefix, animPrefix);
-	const INT32 tempFoundAnimVoteFrames = widePatch ? foundAnimVoteWideFrames : foundAnimVoteFrames;
+	strcpy(tempAnimPrefix, (widePatch ? animWidePrefix : animPrefix));
+	const INT32 tempFoundAnimVoteFrames = (widePatch ? foundAnimVoteWideFrames : foundAnimVoteFrames) - 1;
 
 	// Just in case someone provides LESS widescreen frames than normal frames or vice versa, reset the frame counter to 0
-	if (currentAnimFrame > tempFoundAnimVoteFrames - 1)
+	if (currentAnimFrame > tempFoundAnimVoteFrames)
 		currentAnimFrame = 0;
 
-	patch_t *background = W_CachePatchName(va("%s%d", tempAnimPrefix, currentAnimFrame + 1), PU_PATCH);
-	V_DrawScaledPatch(((vid.width/2) / vid.dupx) - (background->width/2), // Keep the width/height adjustments, for screens that are less wide than 320(?)
-				(vid.height / vid.dupy) - background->height,
-				V_SNAPTOTOP|V_SNAPTOLEFT, background);
+	votebg = W_CachePatchName(va("%s%d", tempAnimPrefix, currentAnimFrame + 1), PU_PATCH);
 
-	if (renderisnewtic && votetic % 2 == 0 && !paused)
-		currentAnimFrame = (currentAnimFrame + 1 > tempFoundAnimVoteFrames - 1) ? 0 : currentAnimFrame + 1;
+	V_DrawCenteredScaledFullScreenPatch(votebg);
+
+	if (renderisnewtic && (votetic % 2 == 0) && !paused)
+		currentAnimFrame = (currentAnimFrame + 1 > tempFoundAnimVoteFrames) ? 0 : (currentAnimFrame + 1);
 }
 
 static void Y_DrawVoteScreenPatch(void)
 {
+	patch_t *votebg = NULL;
 	const boolean widescreen = (vid.width / vid.dupx > 320);
-	const boolean animvote = (foundAnimVoteWideFrames || foundAnimVoteFrames);
 
-	if (animvote)
+	if (foundAnimVoteWideFrames || foundAnimVoteFrames)
 	{
 		Y_DrawAnimatedVoteScreenPatch((foundAnimVoteWideFrames && widescreen));
 		return;
 	}
 
-	patch_t *votebg = bgpatch; // non widescreen patch
+	votebg = bgpatch; // non widescreen patch
 
 	UINT8 prefgametype = (votelevels[0][1] & ~0x80);
 	const boolean widebgreplaced = (prefgametype == GT_MATCH) ? widebattlereplaced : wideracereplaced;
@@ -952,9 +952,7 @@ static void Y_DrawVoteScreenPatch(void)
 		votebg = widebgpatch;
 	}
 
-	V_DrawScaledPatch(((vid.width/2) / vid.dupx) - (votebg->width/2),
-					  (vid.height / vid.dupy) - votebg->height,
-					  V_SNAPTOTOP|V_SNAPTOLEFT, votebg);
+	V_DrawCenteredScaledFullScreenPatch(votebg);
 }
 
 //


### PR DESCRIPTION
Votebackgrounds scale and look completely different on every resolution and highreshudscale setting, which leads to them looking really bad on some specific settings
This adds 3 new ways of handling how they are scaled and displayed to accomidate every possible setting

- Vanilla
as the name implies, this just draws them like vanilla would
- Adaptive
this will try to always make the background fill the screen on both axis
this is the most consistent visually and accomidates patches with padding the best
however a few exceptions might be displayed "offcentered" vertically, since this setting aligns the patches on the bottom of the screen (similar to vanilla)
this is the new default setting
- Vertical-Fill
this attempts to always scale the patch to fill the screen vertically
best setting to see almost all vote backgrounds in "full"
- Horizontal-Fill
this attempts to always scale the patch to fill the screen horizontally
by default this aligns the patch vertically at the bottom of the screen, but will center the background if they do not fit the screen vertically like this
this is also rather consistent looking, but often ends up cutting off parts of the votebackground or looking off on backgrounds that rely on being aligned to the bottom of the screen (vanilla background)

all of this can be changed per "votebgscaling" cvar


**Vanilla:**
![kart0222](https://github.com/user-attachments/assets/8527b130-2897-4af7-b512-e4987436ea1e)

**Adaptive (new default):**
![kart0220](https://github.com/user-attachments/assets/5cee11fb-757f-4388-a42a-23ed894ce8d9)
![kart0216](https://github.com/user-attachments/assets/f0d86cc1-cd87-4597-a68e-ccd25b2fc3b4)

