### PR TITLE
Cleanup Votescreen stuff

### DIFF
--- a/src/d_main.c
+++ b/src/d_main.c
@@ -1812,7 +1812,7 @@ void D_SRB2Main(void)
 		{
 			name = lumpinfo->name;
 
-			if (name[0] == 'M' && name[1] == 'A' && name[2] == 'P') // Ignore the headers
+			if (memcmp(name, "MAP", 3) == 0) // Ignore the headers
 			{
 				INT16 num;
 				if (name[5] != '\0')
@@ -1842,7 +1842,7 @@ void D_SRB2Main(void)
 		{
 			name = lumpinfo->name;
 
-			if (name[0] == 'M' && name[1] == 'A' && name[2] == 'P') // Ignore the headers
+			if (memcmp(name, "MAP", 3) == 0) // Ignore the headers
 			{
 				INT16 num;
 				if (name[5] != '\0')

--- a/src/hu_stuff.c
+++ b/src/hu_stuff.c
@@ -259,8 +259,6 @@ INT32 HU_FallBackFrSpecialLetter(INT32 key)
 	}
 }
 
-
-
 static char cechotext[1024];
 static tic_t cechotimer = 0;
 static tic_t cechoduration = 5*TICRATE;

--- a/src/lua_hudlib.c
+++ b/src/lua_hudlib.c
@@ -1260,15 +1260,10 @@ extern int lib_hudadd(lua_State *L);
 
 static int lib_hudsetvotebackground(lua_State *L)
 {
+	memset(VoteScreen.luaPrefix, 0, sizeof(VoteScreen.luaPrefix));
+
 	if (lua_isnoneornil(L, 1))
 	{
-		if (VoteScreen.luaVoteScreen)
-		{
-			free(VoteScreen.luaVoteScreen);
-		}
-
-		VoteScreen.luaVoteScreen = NULL;
-
 		return 0;
 	}
 
@@ -1279,15 +1274,8 @@ static int lib_hudsetvotebackground(lua_State *L)
 		return luaL_argerror(L, 1, "prefix should 4 characters wide");
 	}
 
-	if (!VoteScreen.luaVoteScreen)
-	{
-		VoteScreen.luaVoteScreen = (char*)malloc(5);
-		VoteScreen.luaVoteScreen[4] = 0;
-	}
-
-	strncpy(VoteScreen.luaVoteScreen, prefix, 4);
-
-	strupr(VoteScreen.luaVoteScreen);
+	strncpy(VoteScreen.luaPrefix, prefix, 4);
+	strupr(VoteScreen.luaPrefix);
 
 	return 0;
 }

--- a/src/lua_hudlib.c
+++ b/src/lua_hudlib.c
@@ -1262,12 +1262,12 @@ static int lib_hudsetvotebackground(lua_State *L)
 {
 	if (lua_isnoneornil(L, 1))
 	{
-		if (luaVoteScreen)
+		if (VoteScreen.luaVoteScreen)
 		{
-			free(luaVoteScreen);
+			free(VoteScreen.luaVoteScreen);
 		}
 
-		luaVoteScreen = NULL;
+		VoteScreen.luaVoteScreen = NULL;
 
 		return 0;
 	}
@@ -1279,15 +1279,15 @@ static int lib_hudsetvotebackground(lua_State *L)
 		return luaL_argerror(L, 1, "prefix should 4 characters wide");
 	}
 
-	if (!luaVoteScreen)
+	if (!VoteScreen.luaVoteScreen)
 	{
-		luaVoteScreen = (char*)malloc(5);
-		luaVoteScreen[4] = 0;
+		VoteScreen.luaVoteScreen = (char*)malloc(5);
+		VoteScreen.luaVoteScreen[4] = 0;
 	}
 
-	strncpy(luaVoteScreen, prefix, 4);
+	strncpy(VoteScreen.luaVoteScreen, prefix, 4);
 
-	strupr(luaVoteScreen);
+	strupr(VoteScreen.luaVoteScreen);
 
 	return 0;
 }

--- a/src/p_setup.c
+++ b/src/p_setup.c
@@ -3197,33 +3197,33 @@ static boolean P_CheckMapReplacements(char *name)
 static boolean P_CheckVoteReplacements(char *name)
 {
 	// widescreen patch Race
-	if (!VoteScreen.wideracereplaced && !memcmp(name, "INTERSCW", 8))
+	if (!VoteScreen.replaced.widerace && !memcmp(name, "INTERSCW", 8))
 	{
-		VoteScreen.wideracereplaced = true;
+		VoteScreen.replaced.widerace = true;
 		return false;
 	}
 
-	if (!VoteScreen.racereplaced && !memcmp(name, "INTERSCR", 8))
+	if (!VoteScreen.replaced.race && !memcmp(name, "INTERSCR", 8))
 	{
-		VoteScreen.racereplaced = true;
+		VoteScreen.replaced.race = true;
 		return false;
 	}
 
 	// widescreen patch Battle
-	if (!VoteScreen.widebattlereplaced && !memcmp(name, "BATTLSCW", 8))
+	if (!VoteScreen.replaced.widebattle && !memcmp(name, "BATTLSCW", 8))
 	{
-		VoteScreen.widebattlereplaced = true;
+		VoteScreen.replaced.widebattle = true;
 		return false;
 	}
 
-	if (!VoteScreen.battlereplaced && !memcmp(name, "BATTLSCR", 8))
+	if (!VoteScreen.replaced.battle && !memcmp(name, "BATTLSCR", 8))
 	{
-		VoteScreen.battlereplaced = true;
+		VoteScreen.replaced.battle = true;
 		return false;
 	}
 
-	if (VoteScreen.wideracereplaced && VoteScreen.racereplaced
-	&& VoteScreen.widebattlereplaced && VoteScreen.battlereplaced)
+	if (VoteScreen.replaced.widerace && VoteScreen.replaced.race
+	&& VoteScreen.replaced.widebattle && VoteScreen.replaced.battle)
 	{
 		return true;
 	}

--- a/src/p_setup.c
+++ b/src/p_setup.c
@@ -67,6 +67,8 @@
 #include "lua_script.h"
 #include "lua_hook.h"
 
+#include "y_inter.h"
+
 #if !defined (UNDER_CE)
 #include <time.h>
 #endif
@@ -3106,12 +3108,6 @@ boolean P_AddWadFile(const char *wadfilename, boolean local)
 	return true;
 }
 
-// check for replacement votescreen backgrounds
-boolean wideracereplaced = false;
-boolean racereplaced = false;
-boolean widebattlereplaced = false;
-boolean battlereplaced = false;
-
 //
 // Add a WAD file and do the per-WAD setup stages.
 // Call P_MultiSetupWadFiles as soon as possible after any number of these.
@@ -3245,10 +3241,11 @@ UINT16 P_PartialAddWadFile(const char *wadfilename, boolean local)
 	// TODO: Experimental SPRTINFO support, test first
 	R_LoadSpriteInfoLumps(wadnum, wadfiles[wadnum]->numlumps);
 
+
 	//
-	// check for votescreen replacements
+	// check for non Lua votescreen replacements
 	//
-	if (!wideracereplaced && !racereplaced && !widebattlereplaced && !battlereplaced)
+	if (!VoteScreen.wideracereplaced && !VoteScreen.racereplaced && !VoteScreen.widebattlereplaced && !VoteScreen.battlereplaced)
 	{
 		lumpinfo = wadfiles[wadnum]->lumpinfo;
 		for (i = 0; i < numlumps; i++, lumpinfo++)
@@ -3256,28 +3253,28 @@ UINT16 P_PartialAddWadFile(const char *wadfilename, boolean local)
 			name = lumpinfo->name;
 
 			// widescreen patch Race
-			if (!wideracereplaced && !strncmp(name, "INTERSCW", 8))
+			if (!VoteScreen.wideracereplaced && !strncmp(name, "INTERSCW", 8))
 			{
-				wideracereplaced = true;
+				VoteScreen.wideracereplaced = true;
 				continue;
 			}
 
-			if (!racereplaced && !strncmp(name, "INTERSCR", 8))
+			if (!VoteScreen.racereplaced && !strncmp(name, "INTERSCR", 8))
 			{
-				racereplaced = true;
+				VoteScreen.racereplaced = true;
 				continue;
 			}
 
 			// widescreen patch Battle
-			if (!widebattlereplaced && !strncmp(name, "BATTLSCW", 8))
+			if (!VoteScreen.widebattlereplaced && !strncmp(name, "BATTLSCW", 8))
 			{
-				widebattlereplaced = true;
+				VoteScreen.widebattlereplaced = true;
 				continue;
 			}
 
-			if (!battlereplaced && !strncmp(name, "BATTLSCR", 8))
+			if (!VoteScreen.battlereplaced && !strncmp(name, "BATTLSCR", 8))
 			{
-				battlereplaced = true;
+				VoteScreen.battlereplaced = true;
 				continue;
 			}
 		}

--- a/src/p_setup.c
+++ b/src/p_setup.c
@@ -3108,17 +3108,137 @@ boolean P_AddWadFile(const char *wadfilename, boolean local)
 	return true;
 }
 
+static size_t sreplaces = 0, mreplaces = 0, digmreplaces = 0;
+
+//
+// search for sound replacements
+//
+static boolean P_CheckSoundReplacements(UINT16 wadnum, char *name, size_t i)
+{
+	size_t j;
+	lumpnum_t lumpnum = (i|(wadnum<<16));
+
+	if (name[0] == 'D')
+	{
+		if (name[1] == 'S')
+		{
+			for (j = 1; j < NUMSFX; j++)
+			{
+				if (S_sfx[j].name && !strnicmp(S_sfx[j].name, name + 2, 6)
+				&& (S_sfx[j].lumpnum != lumpnum) && (S_sfx[j].lumpnum != LUMPERROR))
+				{
+					// the sound will be reloaded when needed,
+					// since sfx->data will be NULL
+					CONS_Debug(DBG_SETUP, "Sound %.8s replaced\n", name);
+
+					I_FreeSfx(&S_sfx[j]);
+
+					// Re-cache it
+					if (S_PrecacheSound())
+						S_sfx[j].data = I_GetSfx(&S_sfx[j]);
+
+					sreplaces++;
+					return true;
+				}
+			}
+		}
+		else if (name[1] == '_')
+		{
+			CONS_Debug(DBG_SETUP, "Music %.8s ignored\n", name);
+			mreplaces++;
+			return true;
+		}
+	}
+	else if (name[0] == 'O' && name[1] == '_')
+	{
+		CONS_Debug(DBG_SETUP, "Music %.8s replaced\n", name);
+		digmreplaces++;
+		return true;
+	}
+
+	return false;
+}
+
+//
+// search for maps
+//
+static boolean P_CheckMapReplacements(char *name)
+{
+	if (memcmp(name, "MAP", 3) == 0) // Ignore the headers
+	{
+		INT16 num;
+
+		if (name[5] != '\0')
+			return false;
+
+		num = (INT16)M_MapNumber(name[3], name[4]);
+
+		// we want to record whether this map exists. if it doesn't have a header, we can assume it's not relephant
+		if (num <= NUMMAPS && mapheaderinfo[num-1])
+		{
+			if (mapheaderinfo[num-1]->menuflags & LF2_EXISTSHACK)
+				G_SetGameModified(multiplayer, true); // oops, double-defined - no record attack privileges for you
+			mapheaderinfo[num-1]->menuflags |= LF2_EXISTSHACK;
+		}
+
+		if (num == gamemap)
+			partadd_replacescurrentmap = true;
+
+		CONS_Printf("%s\n", name);
+		return true;
+	}
+
+	return false;
+}
+
+//
+// check for non Lua votescreen replacements
+//
+static boolean P_CheckVoteReplacements(char *name)
+{
+	// widescreen patch Race
+	if (!VoteScreen.wideracereplaced && !memcmp(name, "INTERSCW", 8))
+	{
+		VoteScreen.wideracereplaced = true;
+		return false;
+	}
+
+	if (!VoteScreen.racereplaced && !memcmp(name, "INTERSCR", 8))
+	{
+		VoteScreen.racereplaced = true;
+		return false;
+	}
+
+	// widescreen patch Battle
+	if (!VoteScreen.widebattlereplaced && !memcmp(name, "BATTLSCW", 8))
+	{
+		VoteScreen.widebattlereplaced = true;
+		return false;
+	}
+
+	if (!VoteScreen.battlereplaced && !memcmp(name, "BATTLSCR", 8))
+	{
+		VoteScreen.battlereplaced = true;
+		return false;
+	}
+
+	return true;
+}
+
 //
 // Add a WAD file and do the per-WAD setup stages.
 // Call P_MultiSetupWadFiles as soon as possible after any number of these.
 //
 UINT16 P_PartialAddWadFile(const char *wadfilename, boolean local)
 {
-	size_t i, j, sreplaces = 0, mreplaces = 0, digmreplaces = 0;
+	size_t i;
 	UINT16 numlumps, wadnum;
 	char *name;
 	boolean mapsadded = false;
+	static boolean allvotereplaced = false;
 	lumpinfo_t *lumpinfo;
+
+	sreplaces = mreplaces = digmreplaces = 0;
 
 	if ((numlumps = W_InitFile(wadfilename, local)) == INT16_MAX)
 	{
@@ -3134,52 +3254,33 @@ UINT16 P_PartialAddWadFile(const char *wadfilename, boolean local)
 
 	wadfiles[wadnum]->localfile = local;
 
-	//
-	// search for sound replacements
-	//
 	lumpinfo = wadfiles[wadnum]->lumpinfo;
 	for (i = 0; i < numlumps; i++, lumpinfo++)
 	{
 		name = lumpinfo->name;
-		lumpnum_t lumpnum = i|(wadnum<<16);
 
-		if (name[0] == 'D')
+		if (P_CheckSoundReplacements(wadnum, name, i))
+			continue;
+
+		if (P_CheckMapReplacements(name))
 		{
-			if (name[1] == 'S') for (j = 1; j < NUMSFX; j++)
-			{
-				if (S_sfx[j].name && !strnicmp(S_sfx[j].name, name + 2, 6) && S_sfx[j].lumpnum != lumpnum && S_sfx[j].lumpnum != LUMPERROR)
-				{
-					// the sound will be reloaded when needed,
-					// since sfx->data will be NULL
-					CONS_Debug(DBG_SETUP, "Sound %.8s replaced\n", name);
-
-					I_FreeSfx(&S_sfx[j]);
-
-					// Re-cache it
-					if (S_PrecacheSound())
-						S_sfx[j].data = I_GetSfx(&S_sfx[j]);
-
-					sreplaces++;
-				}
-			}
-			else if (name[1] == '_')
-			{
-				CONS_Debug(DBG_SETUP, "Music %.8s ignored\n", name);
-				mreplaces++;
-			}
+			mapsadded = true;
+			continue;
 		}
-		else if (name[0] == 'O' && name[1] == '_')
-		{
-			CONS_Debug(DBG_SETUP, "Music %.8s replaced\n", name);
-			digmreplaces++;
-		}
+
+		if (!allvotereplaced && P_CheckVoteReplacements(name))
+			allvotereplaced = true;
 	}
+
 	if (!devparm && sreplaces)
 		CONS_Printf(M_GetText("%s sounds replaced\n"), sizeu1(sreplaces));
 	if (!devparm && mreplaces)
 		CONS_Printf(M_GetText("%s midi musics ignored\n"), sizeu1(mreplaces));
 	if (!devparm && digmreplaces)
 		CONS_Printf(M_GetText("%s digital musics replaced\n"), sizeu1(digmreplaces));
+
+	if (!mapsadded)
+		CONS_Printf(M_GetText("No maps added\n"));
 
 	//
 	// search for sprite replacements
@@ -3205,80 +3306,8 @@ UINT16 P_PartialAddWadFile(const char *wadfilename, boolean local)
 	//
 	S_LoadMusicDefs(wadnum);
 
-	//
-	// search for maps
-	//
-	lumpinfo = wadfiles[wadnum]->lumpinfo;
-	for (i = 0; i < numlumps; i++, lumpinfo++)
-	{
-		name = lumpinfo->name;
-
-		if (name[0] == 'M' && name[1] == 'A' && name[2] == 'P') // Ignore the headers
-		{
-			INT16 num;
-			if (name[5]!='\0')
-				continue;
-			num = (INT16)M_MapNumber(name[3], name[4]);
-
-			// we want to record whether this map exists. if it doesn't have a header, we can assume it's not relephant
-			if (num <= NUMMAPS && mapheaderinfo[num-1])
-			{
-				if (mapheaderinfo[num-1]->menuflags & LF2_EXISTSHACK)
-					G_SetGameModified(multiplayer, true); // oops, double-defined - no record attack privileges for you
-				mapheaderinfo[num-1]->menuflags |= LF2_EXISTSHACK;
-			}
-
-			if (num == gamemap)
-				partadd_replacescurrentmap = true;
-
-			CONS_Printf("%s\n", name);
-			mapsadded = true;
-		}
-	}
-	if (!mapsadded)
-		CONS_Printf(M_GetText("No maps added\n"));
-
 	// TODO: Experimental SPRTINFO support, test first
 	R_LoadSpriteInfoLumps(wadnum, wadfiles[wadnum]->numlumps);
-
-
-	//
-	// check for non Lua votescreen replacements
-	//
-	if (!VoteScreen.wideracereplaced && !VoteScreen.racereplaced && !VoteScreen.widebattlereplaced && !VoteScreen.battlereplaced)
-	{
-		lumpinfo = wadfiles[wadnum]->lumpinfo;
-		for (i = 0; i < numlumps; i++, lumpinfo++)
-		{
-			name = lumpinfo->name;
-
-			// widescreen patch Race
-			if (!VoteScreen.wideracereplaced && !strncmp(name, "INTERSCW", 8))
-			{
-				VoteScreen.wideracereplaced = true;
-				continue;
-			}
-
-			if (!VoteScreen.racereplaced && !strncmp(name, "INTERSCR", 8))
-			{
-				VoteScreen.racereplaced = true;
-				continue;
-			}
-
-			// widescreen patch Battle
-			if (!VoteScreen.widebattlereplaced && !strncmp(name, "BATTLSCW", 8))
-			{
-				VoteScreen.widebattlereplaced = true;
-				continue;
-			}
-
-			if (!VoteScreen.battlereplaced && !strncmp(name, "BATTLSCR", 8))
-			{
-				VoteScreen.battlereplaced = true;
-				continue;
-			}
-		}
-	}
 
 	refreshdirmenu &= ~REFRESHDIR_GAMEDATA; // Under usual circumstances we'd wait for REFRESHDIR_GAMEDATA to disappear the next frame, but it's a bit too dangerous for that...
 	partadd_stage = 0;

--- a/src/p_setup.c
+++ b/src/p_setup.c
@@ -3222,7 +3222,13 @@ static boolean P_CheckVoteReplacements(char *name)
 		return false;
 	}
 
-	return true;
+	if (VoteScreen.wideracereplaced && VoteScreen.racereplaced
+	&& VoteScreen.widebattlereplaced && VoteScreen.battlereplaced)
+	{
+		return true;
+	}
+
+	return false;
 }
 
 //

--- a/src/p_setup.h
+++ b/src/p_setup.h
@@ -68,11 +68,6 @@ void HWR_LoadLevel(boolean reloadinggamestate);
 
 boolean P_AddWadFile(const char *wadfilename, boolean local);
 
-extern boolean wideracereplaced;
-extern boolean racereplaced;
-extern boolean widebattlereplaced;
-extern boolean battlereplaced;
-
 // WARNING: The following functions should be grouped as follows:
 // any amount of PartialAdds followed by MultiSetups until returned true,
 // as soon as possible.

--- a/src/y_inter.c
+++ b/src/y_inter.c
@@ -57,29 +57,17 @@ typedef struct
 
 static y_data_t data;
 
-
 // graphics
-static patch_t *bgpatch = NULL;     // INTERSCR
-static patch_t *widebgpatch = NULL; // INTERSCW
 static patch_t *bgtile = NULL;      // SPECTILE/SRB2BACK
+
 static INT32 timer;
 
 static INT32 intertic;
 static INT32 endtic = -1;
 static INT32 sorttic = -1;
 
-patch_t *animVoteFramesPatches = NULL;
-// VEXTRN - Vote (V) Extra (EXT) Race (R) Normal (N - Normal sized patch)
-// VEXTBN - Vote (V) Extra (EXT) Battle (B) Normal (N - Normal sized patch)
-// VEXTBW - Vote (V) Extra (EXT) Battle (B) Normal (W - Wide patch used in software)
-// VEXTRW - Vote (V) Extra (EXT) Race (R) Normal (W - Wide patch used in software)
-char animPrefix[] = "INTSC";
-char animWidePrefix[] = "INTSW";
-char *luaVoteScreen = NULL;
-
-INT32 currentAnimFrame = 0;
-static INT32 foundAnimVoteFrames = 0;
-static INT32 foundAnimVoteWideFrames = 0;
+// votescreen stuff
+votescreen_t VoteScreen = {0};
 
 intertype_t intertype = int_none;
 
@@ -288,45 +276,54 @@ static void Y_CalculateMatchData(UINT8 rankingsmode, void (*comparison)(INT32))
 }
 
 //
-// Y_AnimatedVoteScreenCheck
+// Y_VoteScreenCheck
 //
-// Check if the lumps exist (checking for VEXTR(N|W)xx for race and VEXTRB(N|W)xx for battle)
-static void Y_AnimatedVoteScreenCheck(void)
+static void Y_VoteScreenCheck(void)
 {
-	char tmpPrefix[] = "INTS";
+	strcpy(VoteScreen.Prefix, "INTS");
 
-	if (luaVoteScreen)
-		strncpy(tmpPrefix, luaVoteScreen, 4);
+	if (VoteScreen.luaVoteScreen)
+		strncpy(VoteScreen.Prefix, VoteScreen.luaVoteScreen, 4);
 	else if (G_BattleGametype())
-		strcpy(tmpPrefix, "BTLS");
+		strcpy(VoteScreen.Prefix, "BTLS");
 
-	strncpy(animPrefix, tmpPrefix, 4);
-	animPrefix[4] = 'C';
-	strncpy(animWidePrefix, tmpPrefix, 4);
-	animWidePrefix[4] = 'W';
-
-	foundAnimVoteFrames = foundAnimVoteWideFrames = 0;
-	currentAnimFrame = 0;
+	VoteScreen.foundLuaVoteFrames = VoteScreen.foundLuaVoteWideFrames = 0;
+	VoteScreen.currentAnimFrame = 0;
 
 	INT32 i = 1;
 
+	// check for lua vote background replacements
 	for (;;)
 	{
-		boolean normalLumpExists = W_LumpExists(va("%sC%d", tmpPrefix, i));
-		boolean wideLumpExists = W_LumpExists(va("%sW%d", tmpPrefix, i));
+		// Check if the lumps exist (checking for VEXTR(N|W)xx for race and VEXTRB(N|W)xx for battle)
+		boolean normalLumpExists = W_LumpExists(va("%sC%d", VoteScreen.Prefix, i));
+		boolean wideLumpExists = W_LumpExists(va("%sW%d", VoteScreen.Prefix, i));
 
 		if (normalLumpExists || wideLumpExists)
 		{
 			if (normalLumpExists)
-				foundAnimVoteFrames++;
+				VoteScreen.foundLuaVoteFrames++;
 
 			if (wideLumpExists)
-				foundAnimVoteWideFrames++;
+				VoteScreen.foundLuaVoteWideFrames++;
 		}
 		else // If we don't find at least frame 1 (e.g VEXTRN1), let's just stop looking
 			break;
 
 		i++;
+	}
+
+	// non lua vote background handling
+	UINT8 prefgametype = (votelevels[0][1] & ~0x80);
+
+	VoteScreen.widebgpatch = VoteScreen.bgpatch = W_CachePatchName(((prefgametype == GT_MATCH) ? "BATTLSCR" : "INTERSCR"), PU_PATCH);
+
+	if (VoteScreen.wideracereplaced || VoteScreen.widebattlereplaced)
+	{
+		if (prefgametype == GT_MATCH && VoteScreen.widebattlereplaced)
+			VoteScreen.widebgpatch = W_CachePatchName("BATTLSCW", PU_PATCH);
+		else if (VoteScreen.wideracereplaced)
+			VoteScreen.widebgpatch = W_CachePatchName("INTERSCW", PU_PATCH);
 	}
 }
 
@@ -894,8 +891,8 @@ static void Y_UnloadData(void)
 		return;
 
 	// unload the background patches
-	UNLOAD(bgpatch);
-	UNLOAD(widebgpatch);
+	UNLOAD(VoteScreen.bgpatch);
+	UNLOAD(VoteScreen.widebgpatch);
 	UNLOAD(bgtile);
 	//UNLOAD(interpic);
 }
@@ -928,27 +925,35 @@ static void Y_DrawVoteBackground(patch_t *patch)
 //
 // Draw animated patch based on frame counter on vote screen
 //
-static void Y_DrawAnimatedVoteScreenPatch(boolean widePatch)
+static void Y_DrawLuaVoteScreenPatch(boolean widePatch)
 {
 	INT32 nextframe = 0;
 	patch_t *votebg = NULL;
-	char tempAnimPrefix[7];
-	const INT32 tempFoundAnimVoteFrames = ((widePatch ? foundAnimVoteWideFrames : foundAnimVoteFrames) - 1);
+	char tempPrefix[7];
+	const INT32 tempfoundAnimLuaVoteFrames = ((widePatch ? VoteScreen.foundLuaVoteWideFrames : VoteScreen.foundLuaVoteFrames) - 1);
 
-	strcpy(tempAnimPrefix, (widePatch ? animWidePrefix : animPrefix));
+	strcpy(tempPrefix, va("%s%s", VoteScreen.Prefix, (widePatch ? "W" : "C")));
+
+	// non animated votescreen
+	if (!tempfoundAnimLuaVoteFrames)
+	{
+		votebg = W_CachePatchName(va("%s1", tempPrefix), PU_PATCH);
+		Y_DrawVoteBackground(votebg);
+		return;
+	}
 
 	// Just in case someone provides LESS widescreen frames than normal frames or vice versa, reset the frame counter to 0
-	if (currentAnimFrame > tempFoundAnimVoteFrames)
-		currentAnimFrame = 0;
+	if (VoteScreen.currentAnimFrame > tempfoundAnimLuaVoteFrames)
+		VoteScreen.currentAnimFrame = 0;
 
-	nextframe = (currentAnimFrame + 1);
+	nextframe = (VoteScreen.currentAnimFrame + 1);
 
-	votebg = W_CachePatchName(va("%s%d", (widePatch ? animWidePrefix : animPrefix), nextframe), PU_PATCH);
+	votebg = W_CachePatchName(va("%s%d", tempPrefix, nextframe), PU_PATCH);
 
 	Y_DrawVoteBackground(votebg);
 
 	if (renderisnewtic && (votetic % 2 == 0) && !paused)
-		currentAnimFrame = (nextframe > tempFoundAnimVoteFrames) ? 0 : nextframe;
+		VoteScreen.currentAnimFrame = (nextframe > tempfoundAnimLuaVoteFrames) ? 0 : nextframe;
 }
 
 static void Y_DrawVoteScreenPatch(void)
@@ -956,22 +961,24 @@ static void Y_DrawVoteScreenPatch(void)
 	patch_t *votebg = NULL;
 	const boolean widescreen = (vid.width / vid.dupx > 320);
 
-	if (foundAnimVoteWideFrames || foundAnimVoteFrames)
+	if (VoteScreen.foundLuaVoteWideFrames || VoteScreen.foundLuaVoteFrames)
 	{
-		Y_DrawAnimatedVoteScreenPatch((foundAnimVoteWideFrames && widescreen));
+		Y_DrawLuaVoteScreenPatch(((widescreen && VoteScreen.foundLuaVoteWideFrames) || !VoteScreen.foundLuaVoteFrames));
 		return;
 	}
 
-	votebg = bgpatch; // non widescreen patch
+	// non widescreen patch
+	votebg = VoteScreen.bgpatch;
 
 	UINT8 prefgametype = (votelevels[0][1] & ~0x80);
-	const boolean widebgreplaced = (prefgametype == GT_MATCH) ? widebattlereplaced : wideracereplaced;
-	const boolean bgreplaced = (prefgametype == GT_MATCH) ? battlereplaced : racereplaced;
+	const boolean widebgreplaced = (prefgametype == GT_MATCH) ? VoteScreen.widebattlereplaced : VoteScreen.wideracereplaced;
+	const boolean bgreplaced = (prefgametype == GT_MATCH) ? VoteScreen.battlereplaced : VoteScreen.racereplaced;
 
+	// we check a bunch of stuff to always have a "valid" fallback
 	if ((widescreen && (widebgreplaced || !bgreplaced))
 	|| (!widescreen && (widebgreplaced && !bgreplaced)))
 	{
-		votebg = widebgpatch;
+		votebg = VoteScreen.widebgpatch; // widescreen patch
 	}
 
 	Y_DrawVoteBackground(votebg);
@@ -1474,7 +1481,6 @@ void Y_VoteTicker(void)
 void Y_StartVote(void)
 {
 	INT32 i = 0;
-	UINT8 prefgametype = (votelevels[0][1] & ~0x80);
 
 	votetic = -1;
 
@@ -1483,10 +1489,8 @@ void Y_StartVote(void)
 		I_Error("voteendtic is dirty");
 #endif
 
-	Y_AnimatedVoteScreenCheck();
+	Y_VoteScreenCheck();
 
-	widebgpatch = W_CachePatchName(((prefgametype == GT_MATCH) ? "BATTLSCW" : "INTERSCW"), PU_PATCH);
-	bgpatch = W_CachePatchName(((prefgametype == GT_MATCH) ? "BATTLSCR" : "INTERSCR"), PU_PATCH);
 	cursor = W_CachePatchName("M_CURSOR", PU_PATCH);
 	cursor1 = W_CachePatchName("P1CURSOR", PU_PATCH);
 	cursor2 = W_CachePatchName("P2CURSOR", PU_PATCH);
@@ -1591,8 +1595,8 @@ static void Y_UnloadVoteData(void)
 	if (rendermode != render_soft)
 		return;
 
-	UNLOAD(widebgpatch);
-	UNLOAD(bgpatch);
+	UNLOAD(VoteScreen.widebgpatch);
+	UNLOAD(VoteScreen.bgpatch);
 	UNLOAD(cursor);
 	UNLOAD(cursor1);
 	UNLOAD(cursor2);

--- a/src/y_inter.c
+++ b/src/y_inter.c
@@ -66,9 +66,6 @@ static INT32 intertic;
 static INT32 endtic = -1;
 static INT32 sorttic = -1;
 
-// votescreen stuff
-votescreen_t VoteScreen = {0};
-
 intertype_t intertype = int_none;
 
 static huddrawlist_h luahuddrawlist_intermission = NULL;
@@ -106,17 +103,13 @@ typedef struct
 	boolean loaded;
 } y_voteclient;
 
+// votescreen stuff
+votescreen_t VoteScreen = {0};
+
 static y_votelvlinfo levelinfo[5];
 static y_voteclient voteclient;
 static INT32 votetic;
 static INT32 voteendtic = -1;
-static patch_t *cursor = NULL;
-static patch_t *cursor1 = NULL;
-static patch_t *cursor2 = NULL;
-static patch_t *cursor3 = NULL;
-static patch_t *cursor4 = NULL;
-static patch_t *randomlvl = NULL;
-static patch_t *rubyicon = NULL;
 
 static void Y_UnloadVoteData(void);
 
@@ -891,7 +884,56 @@ static void Y_UnloadData(void)
 
 // SRB2Kart: Voting!
 
-static void Y_DrawVoteBackground(patch_t *patch)
+//
+// Y_VoteScreenCheck
+//
+static void Y_VoteScreenCheck(void)
+{
+	strcpy(VoteScreen.Prefix, "INTS");
+
+	if (VoteScreen.luaPrefix[0] != 0)
+		strlcpy(VoteScreen.Prefix, VoteScreen.luaPrefix, sizeof(VoteScreen.Prefix));
+	else if (G_BattleGametype())
+		strcpy(VoteScreen.Prefix, "BTLS");
+
+	VoteScreen.foundLuaVoteFrames = VoteScreen.foundLuaVoteWideFrames = 0;
+	VoteScreen.currentAnimFrame = 0;
+
+	INT32 i = 1;
+
+	// check for lua vote background replacements
+	for (;;)
+	{
+		// Check if the lumps exist (checking for VEXTR(N|W)xx for race and VEXTRB(N|W)xx for battle)
+		boolean normalLumpExists = W_LumpExists(va("%sC%d", VoteScreen.Prefix, i));
+		boolean wideLumpExists = W_LumpExists(va("%sW%d", VoteScreen.Prefix, i));
+
+		if (normalLumpExists || wideLumpExists)
+		{
+			if (normalLumpExists)
+				VoteScreen.foundLuaVoteFrames++;
+
+			if (wideLumpExists)
+				VoteScreen.foundLuaVoteWideFrames++;
+		}
+		else // If we don't find at least frame 1 (e.g VEXTRN1), let's just stop looking
+			break;
+
+		i++;
+	}
+
+	// non lua vote background handling
+	boolean prefbattletype = ((votelevels[0][1] & ~0x80) == GT_MATCH);
+	VoteScreen.widebgpatch = W_CachePatchName((prefbattletype ? "BATTLSCW" : "INTERSCW"), PU_PATCH);
+	VoteScreen.bgpatch = W_CachePatchName((prefbattletype ? "BATTLSCR" : "INTERSCR"), PU_PATCH);
+}
+
+//
+// Y_VoteBackgroundDrawer
+//
+// Determines which patch drawer to use for scaling
+//
+static void Y_VoteBackgroundDrawer(patch_t *patch)
 {
 	switch (cv_votebgscaling.value)
 	{
@@ -913,26 +955,30 @@ static void Y_DrawVoteBackground(patch_t *patch)
 	}
 }
 
-// Y_DrawAnimatedVoteScreenPatch
 //
-// Draw animated patch based on frame counter on vote screen
+// Y_DrawLuaVoteScreenPatch
+//
+// Handles votebackgrounds set by "setVoteBackground"
+// Aswell as animated patches
 //
 static void Y_DrawLuaVoteScreenPatch(boolean widePatch)
 {
 	INT32 nextframe = 0;
 	patch_t *votebg = NULL;
-	char tempPrefix[7];
+	char tempPrefix[6];
 	const INT32 tempfoundAnimLuaVoteFrames = ((widePatch ? VoteScreen.foundLuaVoteWideFrames : VoteScreen.foundLuaVoteFrames) - 1);
 
 	strcpy(tempPrefix, va("%s%s", VoteScreen.Prefix, (widePatch ? "W" : "C")));
 
-	// non animated votescreen
+	// Draw non animated patch
 	if (!tempfoundAnimLuaVoteFrames)
 	{
 		votebg = W_CachePatchName(va("%s1", tempPrefix), PU_PATCH);
-		Y_DrawVoteBackground(votebg);
+		Y_VoteBackgroundDrawer(votebg);
 		return;
 	}
+
+	// Draw animated patch based on frame counter on vote screen
 
 	// Just in case someone provides LESS widescreen frames than normal frames or vice versa, reset the frame counter to 0
 	if (VoteScreen.currentAnimFrame > tempfoundAnimLuaVoteFrames)
@@ -942,12 +988,15 @@ static void Y_DrawLuaVoteScreenPatch(boolean widePatch)
 
 	votebg = W_CachePatchName(va("%s%d", tempPrefix, nextframe), PU_PATCH);
 
-	Y_DrawVoteBackground(votebg);
+	Y_VoteBackgroundDrawer(votebg);
 
 	if (renderisnewtic && (votetic % 2 == 0) && !paused)
 		VoteScreen.currentAnimFrame = (nextframe > tempfoundAnimLuaVoteFrames) ? 0 : nextframe;
 }
 
+//
+// Y_DrawVoteScreenPatch
+//
 static void Y_DrawVoteScreenPatch(void)
 {
 	patch_t *votebg = NULL;
@@ -963,8 +1012,8 @@ static void Y_DrawVoteScreenPatch(void)
 	votebg = VoteScreen.bgpatch;
 
 	UINT8 prefgametype = (votelevels[0][1] & ~0x80);
-	const boolean widebgreplaced = (prefgametype == GT_MATCH) ? VoteScreen.widebattlereplaced : VoteScreen.wideracereplaced;
-	const boolean bgreplaced = (prefgametype == GT_MATCH) ? VoteScreen.battlereplaced : VoteScreen.racereplaced;
+	const boolean widebgreplaced = (prefgametype == GT_MATCH) ? VoteScreen.replaced.widebattle : VoteScreen.replaced.widerace;
+	const boolean bgreplaced = (prefgametype == GT_MATCH) ? VoteScreen.replaced.battle : VoteScreen.replaced.race;
 
 	// we check a bunch of stuff to always have a "valid" fallback
 	if ((widescreen && (widebgreplaced || !bgreplaced))
@@ -973,7 +1022,7 @@ static void Y_DrawVoteScreenPatch(void)
 		votebg = VoteScreen.widebgpatch; // widescreen patch
 	}
 
-	Y_DrawVoteBackground(votebg);
+	Y_VoteBackgroundDrawer(votebg);
 }
 
 //
@@ -1036,7 +1085,7 @@ void Y_VoteDrawer(void)
 		if (i == 3)
 		{
 			str = "RANDOM";
-			pic = randomlvl;
+			pic = VoteScreen.randomlvl;
 		}
 		else
 		{
@@ -1060,7 +1109,7 @@ void Y_VoteDrawer(void)
 
 				if (!splitscreen)
 				{
-					thiscurs = cursor;
+					thiscurs = VoteScreen.cursor[0];
 					p = consoleplayer;
 					color = levelinfo[i].gtc;
 					colormap = NULL;
@@ -1070,19 +1119,19 @@ void Y_VoteDrawer(void)
 					switch (j)
 					{
 						case 1:
-							thiscurs = cursor2;
+							thiscurs = VoteScreen.cursor[2];
 							p = displayplayers[1];
 							break;
 						case 2:
-							thiscurs = cursor3;
+							thiscurs = VoteScreen.cursor[3];
 							p = displayplayers[2];
 							break;
 						case 3:
-							thiscurs = cursor4;
+							thiscurs = VoteScreen.cursor[4];
 							p = displayplayers[3];
 							break;
 						default:
-							thiscurs = cursor1;
+							thiscurs = VoteScreen.cursor[1];
 							p = displayplayers[0];
 							break;
 					}
@@ -1110,7 +1159,7 @@ void Y_VoteDrawer(void)
 			else
 			{
 				V_DrawFixedPatch((BASEVIDWIDTH-20)<<FRACBITS, (y)<<FRACBITS, FRACUNIT/2, V_FLIP|V_SNAPTORIGHT, pic, 0);
-				V_DrawFixedPatch((BASEVIDWIDTH-60)<<FRACBITS, ((y+25)<<FRACBITS) - (rubyheight<<1), FRACUNIT, V_SNAPTORIGHT, rubyicon, NULL);
+				V_DrawFixedPatch((BASEVIDWIDTH-60)<<FRACBITS, ((y+25)<<FRACBITS) - (rubyheight<<1), FRACUNIT, V_SNAPTORIGHT, VoteScreen.rubyicon, NULL);
 			}
 
 			V_DrawRightAlignedThinString(BASEVIDWIDTH-21, 40+y, V_SNAPTORIGHT|V_6WIDTHSPACE, str);
@@ -1134,7 +1183,7 @@ void Y_VoteDrawer(void)
 			else
 			{
 				V_DrawFixedPatch((BASEVIDWIDTH-20)<<FRACBITS, y<<FRACBITS, FRACUNIT/4, V_FLIP|V_SNAPTORIGHT, pic, 0);
-				V_DrawFixedPatch((BASEVIDWIDTH-40)<<FRACBITS, (y<<FRACBITS) + (25<<(FRACBITS-1)) - rubyheight, FRACUNIT/2, V_SNAPTORIGHT, rubyicon, NULL);
+				V_DrawFixedPatch((BASEVIDWIDTH-40)<<FRACBITS, (y<<FRACBITS) + (25<<(FRACBITS-1)) - rubyheight, FRACUNIT/2, V_SNAPTORIGHT, VoteScreen.rubyicon, NULL);
 			}
 
 			if (levelinfo[i].gts)
@@ -1163,13 +1212,13 @@ void Y_VoteDrawer(void)
 			patch_t *pic;
 
 			if (votes[i] >= 3 && (i != pickedvote || voteendtic == -1))
-				pic = randomlvl;
+				pic = VoteScreen.randomlvl;
 			else
 				pic = levelinfo[votes[i]].pic;
 
 			if (!timer && i == voteclient.ranim)
 			{
-				V_DrawScaledPatch(x-18, y+9, V_SNAPTOLEFT, cursor);
+				V_DrawScaledPatch(x-18, y+9, V_SNAPTOLEFT, VoteScreen.cursor[0]);
 				if (voteendtic != -1 && !(votetic % 4))
 					V_DrawFill(x-1, y-1, 42, 27, 120|V_SNAPTOLEFT);
 				else
@@ -1181,7 +1230,7 @@ void Y_VoteDrawer(void)
 			else
 			{
 				V_DrawFixedPatch((x+40)<<FRACBITS, (y)<<FRACBITS, FRACUNIT/4, V_SNAPTOLEFT|V_FLIP, pic, 0);
-				V_DrawFixedPatch((x+20)<<FRACBITS, (y<<FRACBITS) + (25<<(FRACBITS-1)) - rubyheight, FRACUNIT/2, V_SNAPTOLEFT, rubyicon, NULL);
+				V_DrawFixedPatch((x+20)<<FRACBITS, (y<<FRACBITS) + (25<<(FRACBITS-1)) - rubyheight, FRACUNIT/2, V_SNAPTOLEFT, VoteScreen.rubyicon, NULL);
 			}
 
 			if (levelinfo[votes[i]].gts)
@@ -1470,6 +1519,22 @@ void Y_VoteTicker(void)
 //
 // MK online style voting screen, appears after intermission
 //
+
+static void Y_InitVoteDrawing(void)
+{
+	// setup the background patches
+	Y_VoteScreenCheck();
+
+	VoteScreen.cursor[0] = W_CachePatchName("M_CURSOR", PU_PATCH);
+	VoteScreen.cursor[1] = W_CachePatchName("P1CURSOR", PU_PATCH);
+	VoteScreen.cursor[2] = W_CachePatchName("P2CURSOR", PU_PATCH);
+	VoteScreen.cursor[3] = W_CachePatchName("P3CURSOR", PU_PATCH);
+	VoteScreen.cursor[4] = W_CachePatchName("P4CURSOR", PU_PATCH);
+
+	VoteScreen.randomlvl = W_CachePatchName("RANDOMLV", PU_PATCH);
+	VoteScreen.rubyicon  = W_CachePatchName("RUBYICON", PU_PATCH);
+}
+
 void Y_StartVote(void)
 {
 	INT32 i = 0;
@@ -1481,15 +1546,8 @@ void Y_StartVote(void)
 		I_Error("voteendtic is dirty");
 #endif
 
-	Y_VoteScreenCheck();
-
-	cursor = W_CachePatchName("M_CURSOR", PU_PATCH);
-	cursor1 = W_CachePatchName("P1CURSOR", PU_PATCH);
-	cursor2 = W_CachePatchName("P2CURSOR", PU_PATCH);
-	cursor3 = W_CachePatchName("P3CURSOR", PU_PATCH);
-	cursor4 = W_CachePatchName("P4CURSOR", PU_PATCH);
-	randomlvl = W_CachePatchName("RANDOMLV", PU_PATCH);
-	rubyicon = W_CachePatchName("RUBYICON", PU_PATCH);
+	// cache vote patches
+	Y_InitVoteDrawing();
 
 	timer = cv_votetime.value*TICRATE;
 	pickedvote = -1;
@@ -1589,13 +1647,13 @@ static void Y_UnloadVoteData(void)
 
 	UNLOAD(VoteScreen.widebgpatch);
 	UNLOAD(VoteScreen.bgpatch);
-	UNLOAD(cursor);
-	UNLOAD(cursor1);
-	UNLOAD(cursor2);
-	UNLOAD(cursor3);
-	UNLOAD(cursor4);
-	UNLOAD(randomlvl);
-	UNLOAD(rubyicon);
+	UNLOAD(VoteScreen.cursor[0]);
+	UNLOAD(VoteScreen.cursor[1]);
+	UNLOAD(VoteScreen.cursor[2]);
+	UNLOAD(VoteScreen.cursor[3]);
+	UNLOAD(VoteScreen.cursor[4]);
+	UNLOAD(VoteScreen.randomlvl);
+	UNLOAD(VoteScreen.rubyicon);
 
 	UNLOAD(levelinfo[3].pic);
 	UNLOAD(levelinfo[2].pic);

--- a/src/y_inter.c
+++ b/src/y_inter.c
@@ -282,8 +282,8 @@ static void Y_VoteScreenCheck(void)
 {
 	strcpy(VoteScreen.Prefix, "INTS");
 
-	if (VoteScreen.luaVoteScreen)
-		strncpy(VoteScreen.Prefix, VoteScreen.luaVoteScreen, 4);
+	if (VoteScreen.luaPrefix[0] != 0)
+		strlcpy(VoteScreen.Prefix, VoteScreen.luaPrefix, sizeof(VoteScreen.Prefix));
 	else if (G_BattleGametype())
 		strcpy(VoteScreen.Prefix, "BTLS");
 

--- a/src/y_inter.c
+++ b/src/y_inter.c
@@ -314,17 +314,9 @@ static void Y_VoteScreenCheck(void)
 	}
 
 	// non lua vote background handling
-	UINT8 prefgametype = (votelevels[0][1] & ~0x80);
-
-	VoteScreen.widebgpatch = VoteScreen.bgpatch = W_CachePatchName(((prefgametype == GT_MATCH) ? "BATTLSCR" : "INTERSCR"), PU_PATCH);
-
-	if (VoteScreen.wideracereplaced || VoteScreen.widebattlereplaced)
-	{
-		if (prefgametype == GT_MATCH && VoteScreen.widebattlereplaced)
-			VoteScreen.widebgpatch = W_CachePatchName("BATTLSCW", PU_PATCH);
-		else if (VoteScreen.wideracereplaced)
-			VoteScreen.widebgpatch = W_CachePatchName("INTERSCW", PU_PATCH);
-	}
+	boolean prefbattletype = ((votelevels[0][1] & ~0x80) == GT_MATCH);
+	VoteScreen.widebgpatch = W_CachePatchName((prefbattletype ? "BATTLSCW" : "INTERSCW"), PU_PATCH);
+	VoteScreen.bgpatch = W_CachePatchName((prefbattletype ? "BATTLSCR" : "INTERSCR"), PU_PATCH);
 }
 
 // Y_PlayerStandingsDrawer
@@ -878,7 +870,7 @@ static void Y_FollowIntermission(void)
 	G_AfterIntermission();
 }
 
-#define UNLOAD(x) if (x) {Patch_Free(x);} x = NULL;
+#define UNLOAD(x) {if ((x) != NULL) {Patch_Free(x);} x = NULL;}
 
 //
 // Y_UnloadData

--- a/src/y_inter.c
+++ b/src/y_inter.c
@@ -870,11 +870,6 @@ static void Y_FollowIntermission(void)
 //
 static void Y_UnloadData(void)
 {
-	// In hardware mode, don't Z_ChangeTag a pointer returned by W_CachePatchName().
-	// It doesn't work and is unnecessary.
-	if (rendermode != render_soft)
-		return;
-
 	// unload the background patches
 	UNLOAD(VoteScreen.bgpatch);
 	UNLOAD(VoteScreen.widebgpatch);
@@ -1641,9 +1636,6 @@ void Y_EndVote(void)
 static void Y_UnloadVoteData(void)
 {
 	voteclient.loaded = false;
-
-	if (rendermode != render_soft)
-		return;
 
 	UNLOAD(VoteScreen.widebgpatch);
 	UNLOAD(VoteScreen.bgpatch);

--- a/src/y_inter.c
+++ b/src/y_inter.c
@@ -1474,6 +1474,9 @@ void Y_VoteTicker(void)
 
 static void Y_InitVoteDrawing(void)
 {
+	if (dedicated)
+		return;
+
 	// setup the background patches
 	Y_VoteScreenCheck();
 
@@ -1565,11 +1568,14 @@ void Y_StartVote(void)
 			levelinfo[i].gts = NULL;
 
 		// set up the pic
-		lumpnum = W_CheckNumForName(va("%sP", G_BuildMapName(votelevels[i][0]+1)));
-		if (lumpnum != LUMPERROR)
-			levelinfo[i].pic = W_CachePatchName(va("%sP", G_BuildMapName(votelevels[i][0]+1)), PU_PATCH);
-		else
-			levelinfo[i].pic = W_CachePatchName("BLANKLVL", PU_PATCH);
+		if (!dedicated)
+		{
+			lumpnum = W_CheckNumForName(va("%sP", G_BuildMapName(votelevels[i][0]+1)));
+			if (lumpnum != LUMPERROR)
+				levelinfo[i].pic = W_CachePatchName(va("%sP", G_BuildMapName(votelevels[i][0]+1)), PU_PATCH);
+			else
+				levelinfo[i].pic = W_CachePatchName("BLANKLVL", PU_PATCH);
+		}
 	}
 
 	voteclient.loaded = true;

--- a/src/y_inter.c
+++ b/src/y_inter.c
@@ -845,7 +845,8 @@ void Y_StartIntermission(void)
 //
 void Y_EndIntermission(void)
 {
-	Y_UnloadData();
+	if (!dedicated)
+		Y_UnloadData();
 
 	endtic = -1;
 	sorttic = -1;
@@ -1636,6 +1637,9 @@ void Y_EndVote(void)
 static void Y_UnloadVoteData(void)
 {
 	voteclient.loaded = false;
+
+	if (dedicated)
+		return;
 
 	UNLOAD(VoteScreen.widebgpatch);
 	UNLOAD(VoteScreen.bgpatch);

--- a/src/y_inter.c
+++ b/src/y_inter.c
@@ -268,50 +268,6 @@ static void Y_CalculateMatchData(UINT8 rankingsmode, void (*comparison)(INT32))
 	}
 }
 
-//
-// Y_VoteScreenCheck
-//
-static void Y_VoteScreenCheck(void)
-{
-	strcpy(VoteScreen.Prefix, "INTS");
-
-	if (VoteScreen.luaPrefix[0] != 0)
-		strlcpy(VoteScreen.Prefix, VoteScreen.luaPrefix, sizeof(VoteScreen.Prefix));
-	else if (G_BattleGametype())
-		strcpy(VoteScreen.Prefix, "BTLS");
-
-	VoteScreen.foundLuaVoteFrames = VoteScreen.foundLuaVoteWideFrames = 0;
-	VoteScreen.currentAnimFrame = 0;
-
-	INT32 i = 1;
-
-	// check for lua vote background replacements
-	for (;;)
-	{
-		// Check if the lumps exist (checking for VEXTR(N|W)xx for race and VEXTRB(N|W)xx for battle)
-		boolean normalLumpExists = W_LumpExists(va("%sC%d", VoteScreen.Prefix, i));
-		boolean wideLumpExists = W_LumpExists(va("%sW%d", VoteScreen.Prefix, i));
-
-		if (normalLumpExists || wideLumpExists)
-		{
-			if (normalLumpExists)
-				VoteScreen.foundLuaVoteFrames++;
-
-			if (wideLumpExists)
-				VoteScreen.foundLuaVoteWideFrames++;
-		}
-		else // If we don't find at least frame 1 (e.g VEXTRN1), let's just stop looking
-			break;
-
-		i++;
-	}
-
-	// non lua vote background handling
-	boolean prefbattletype = ((votelevels[0][1] & ~0x80) == GT_MATCH);
-	VoteScreen.widebgpatch = W_CachePatchName((prefbattletype ? "BATTLSCW" : "INTERSCW"), PU_PATCH);
-	VoteScreen.bgpatch = W_CachePatchName((prefbattletype ? "BATTLSCR" : "INTERSCR"), PU_PATCH);
-}
-
 // Y_PlayerStandingsDrawer
 //
 // Handles drawing the center-of-screen player standings.

--- a/src/y_inter.h
+++ b/src/y_inter.h
@@ -10,7 +10,6 @@
 /// \brief Tally screens, or "Intermissions" as they were formally called in Doom
 
 extern boolean usebuffer;
-extern char *luaVoteScreen;
 
 void Y_IntermissionDrawer(void);
 void Y_Ticker(void);
@@ -55,3 +54,27 @@ typedef enum
 	int_classicrace, // Competition
 } intertype_t;
 extern intertype_t intertype;
+
+// VEXTRN - Vote (V) Extra (EXT) Race (R) Normal (N - Normal sized patch)
+// VEXTRW - Vote (V) Extra (EXT) Race (R) Normal (W - Wide patch)
+// VEXTBN - Vote (V) Extra (EXT) Battle (B) Normal (N - Normal sized patch)
+// VEXTBW - Vote (V) Extra (EXT) Battle (B) Normal (W - Wide patch)
+typedef struct
+{
+	char Prefix[5];                 // Race = INTSX, Battle = BTLSX
+	char *luaVoteScreen;            // lua prefix
+
+	INT32 currentAnimFrame;         // current animated background frame
+
+	INT32 foundLuaVoteFrames;       // normal lua patch frames
+	INT32 foundLuaVoteWideFrames;   // wide lua patch frames
+
+	boolean racereplaced;           // non lua race patch replaced
+	boolean wideracereplaced;       // non lua wide race patch replaced
+	boolean battlereplaced;         // non lua battle patch replaced
+	boolean widebattlereplaced;     // non lua wide battle patch replaced
+
+	patch_t *bgpatch;               // votebackground patch
+	patch_t *widebgpatch;           // wide votebackground patch
+} votescreen_t;
+extern votescreen_t VoteScreen;

--- a/src/y_inter.h
+++ b/src/y_inter.h
@@ -62,7 +62,7 @@ extern intertype_t intertype;
 typedef struct
 {
 	char Prefix[5];                 // Race = INTSX, Battle = BTLSX
-	char *luaVoteScreen;            // lua prefix
+	char luaPrefix[5];              // prefix for lua votescreens
 
 	INT32 currentAnimFrame;         // current animated background frame
 

--- a/src/y_inter.h
+++ b/src/y_inter.h
@@ -55,6 +55,15 @@ typedef enum
 } intertype_t;
 extern intertype_t intertype;
 
+// Votescreen stuff
+typedef struct
+{
+	boolean race;       // non lua race patch replaced
+	boolean widerace;   // non lua widescreen race patch replaced
+	boolean battle;     // non lua battle patch replaced
+	boolean widebattle; // non lua widescreen battle patch replaced
+} votereplace_t;
+
 // VEXTRN - Vote (V) Extra (EXT) Race (R) Normal (N - Normal sized patch)
 // VEXTRW - Vote (V) Extra (EXT) Race (R) Normal (W - Wide patch)
 // VEXTBN - Vote (V) Extra (EXT) Battle (B) Normal (N - Normal sized patch)
@@ -67,14 +76,15 @@ typedef struct
 	INT32 currentAnimFrame;         // current animated background frame
 
 	INT32 foundLuaVoteFrames;       // normal lua patch frames
-	INT32 foundLuaVoteWideFrames;   // wide lua patch frames
+	INT32 foundLuaVoteWideFrames;   // widescreen lua patch frames
 
-	boolean racereplaced;           // non lua race patch replaced
-	boolean wideracereplaced;       // non lua wide race patch replaced
-	boolean battlereplaced;         // non lua battle patch replaced
-	boolean widebattlereplaced;     // non lua wide battle patch replaced
+	votereplace_t replaced;         // checks which non lua patch has been replaced
 
 	patch_t *bgpatch;               // votebackground patch
 	patch_t *widebgpatch;           // wide votebackground patch
+
+	patch_t *cursor[5];             // cursor patches
+	patch_t *randomlvl;             // randomlevel patch
+	patch_t *rubyicon;              // encore ruby patch
 } votescreen_t;
 extern votescreen_t VoteScreen;


### PR DESCRIPTION
Just puts everything votescreen related into a struct, renames some functions and variables for better clarity on their intentions
Gets rid of redundant variables and bloat
Also makes votepatches be properly freed in opengl aswell (missed this with the patch refactor)
Ensures dedicated does neither cache or free vote patches
And also simplyfies the 3 loops in P_PartialAddWadFile into one loop, which slightly speeds up addon loading (since we dont have to check every lump in a wad file 3 times)