### PR TITLE
Fixed help command

### DIFF
--- a/src/command.c
+++ b/src/command.c
@@ -838,10 +838,15 @@ static void COM_Help_f(void)
 			{
 				{
 					if (!stricmp(cvar->PossibleValue[0].strvalue, "MIN") && !stricmp(cvar->PossibleValue[1].strvalue, "MAX"))
-					{
+					{	
 						if (floatmode)
-							CONS_Printf("  range from %f to %f\n", FIXED_TO_FLOAT(cvar->PossibleValue[0].value),
-								FIXED_TO_FLOAT(cvar->PossibleValue[1].value));
+						{
+							float fu = FIXED_TO_FLOAT(cvar->PossibleValue[0].value);
+							float ck = FIXED_TO_FLOAT(cvar->PossibleValue[1].value);
+							CONS_Printf("  range from %ld%s to %ld%s\n",
+									(long)fu, M_Ftrim(fu),
+									(long)ck, M_Ftrim(ck));
+						}
 						else
 							CONS_Printf("  range from %d to %d\n", cvar->PossibleValue[0].value,
 								cvar->PossibleValue[1].value);
@@ -1038,7 +1043,10 @@ static void COM_Add_f(void)
 	}
 
 	if (( cvar->flags & CV_FLOAT ))
-		CV_Set(cvar, va("%f", FIXED_TO_FLOAT (cvar->value) + atof(COM_Argv(2))));
+	{
+		float n =FIXED_TO_FLOAT (cvar->value) + atof(COM_Argv(2));
+		CV_Set(cvar, va("%ld%s", (long)n, M_Ftrim(n)));
+	}
 	else
 		CV_AddValue(cvar, atoi(COM_Argv(2)));
 }

--- a/src/command.c
+++ b/src/command.c
@@ -816,12 +816,17 @@ static void COM_Help_f(void)
 		cvar = CV_FindVar(help);
 		if (cvar)
 		{
+			boolean floatmode = false;
+			const char *cvalue = NULL;
 			CONS_Printf("\x82""Variable %s:\n", cvar->name);
 			CONS_Printf(M_GetText("  flags: "));
 			if (cvar->flags & CV_SAVE)
 				CONS_Printf("AUTOSAVE ");
 			if (cvar->flags & CV_FLOAT)
+			{
 				CONS_Printf("FLOAT ");
+				floatmode = true;
+			}
 			if (cvar->flags & CV_NETVAR)
 				CONS_Printf("NETVAR ");
 			if (cvar->flags & CV_CALL)
@@ -831,30 +836,38 @@ static void COM_Help_f(void)
 			CONS_Printf("\n");
 			if (cvar->PossibleValue)
 			{
-				if (!stricmp(cvar->PossibleValue[0].strvalue, "MIN") && !stricmp(cvar->PossibleValue[1].strvalue, "MAX"))
 				{
-					CONS_Printf("  range from %d to %d\n", cvar->PossibleValue[0].value,
-						cvar->PossibleValue[1].value);
-					i = 2;
-				}
+					if (!stricmp(cvar->PossibleValue[0].strvalue, "MIN") && !stricmp(cvar->PossibleValue[1].strvalue, "MAX"))
+					{
+						if (floatmode)
+							CONS_Printf("  range from %f to %f\n", FIXED_TO_FLOAT(cvar->PossibleValue[0].value),
+								FIXED_TO_FLOAT(cvar->PossibleValue[1].value));
+						else
+							CONS_Printf("  range from %d to %d\n", cvar->PossibleValue[0].value,
+								cvar->PossibleValue[1].value);
+						i = 2;
+					}
 
-				{
-					const char *cvalue = NULL;
 					//CONS_Printf(M_GetText("  possible value : %s\n"), cvar->name);
 					while (cvar->PossibleValue[i].strvalue)
 					{
-						CONS_Printf("  %-2d : %s\n", cvar->PossibleValue[i].value,
-							cvar->PossibleValue[i].strvalue);
+						if (floatmode)
+							CONS_Printf("  %-2f : %s\n", FIXED_TO_FLOAT(cvar->PossibleValue[i].value),
+								cvar->PossibleValue[i].strvalue);
+						else
+							CONS_Printf("  %-2d : %s\n", cvar->PossibleValue[i].value,
+								cvar->PossibleValue[i].strvalue);
 						if (cvar->PossibleValue[i].value == cvar->value)
 							cvalue = cvar->PossibleValue[i].strvalue;
 						i++;
 					}
-					if (cvalue)
-						CONS_Printf(" Current value: %s\n", cvalue);
-					else
-						CONS_Printf(" Current value: %d\n", cvar->value);
 				}
 			}
+
+			if (cvalue)
+				CONS_Printf(" Current value: %s\n", cvalue);
+			else if (cvar->string)
+				CONS_Printf(" Current value: %s\n", cvar->string);
 			else
 				CONS_Printf(" Current value: %d\n", cvar->value);
 		}

--- a/src/m_menu.c
+++ b/src/m_menu.c
@@ -3602,8 +3602,8 @@ static void M_ChangeCvar(INT32 choice)
 		char s[20];
 		float increment;
 
-		increment = (currentMenu->menuitems[itemOn].status & IT_CV_BIGFLOAT) ? 0.5f : (1.0f/16.0f);
-		sprintf(s, "%f",FIXED_TO_FLOAT(cv->value)+(choice)*increment);
+		increment = FIXED_TO_FLOAT(cv->value)+(choice)*((currentMenu->menuitems[itemOn].status & IT_CV_BIGFLOAT) ? 0.5f : (1.0f/16.0f));
+		sprintf(s,"%ld%s",(long)increment,M_Ftrim(increment));
 		CV_Set(cv, s);
 	}
 	else

--- a/src/m_misc.c
+++ b/src/m_misc.c
@@ -1965,6 +1965,25 @@ char *M_GetToken(const char *inputString)
 	return texturesToken;
 }
 
+
+const char * M_Ftrim (double f)
+{
+	static char dig[9];/* "0." + 6 digits (6 is printf's default) */
+	int i;
+	/* I know I said it's the default, but just in case... */
+	sprintf(dig, "%.6f", fabs(modf(f, &f)));
+	/* trim trailing zeroes */
+	for (i = strlen(dig)-1; dig[i] == '0'; --i)
+		;
+	if (dig[i] == '.')/* :NOTHING: */
+		return "";
+	else
+	{
+		dig[i + 1] = '\0';
+		return &dig[1];/* skip the 0 */
+	}
+}
+
 /** Count bits in a number.
   */
 UINT8 M_CountBits(UINT32 num, UINT8 size)

--- a/src/m_misc.h
+++ b/src/m_misc.h
@@ -104,6 +104,12 @@ boolean M_IsPathAbsolute (const char *path);
 void    M_MkdirEach      (const char *path, int start, int mode);
 void    M_MkdirEachUntil (const char *path, int start, int end, int mode);
 
+/*
+Return dot and then the fractional part of a float, without
+trailing zeros, or "" if the fractional part is zero.
+*/
+const char * M_Ftrim (double);
+
 // counting bits, for weapon ammo code, usually
 FUNCMATH UINT8 M_CountBits(UINT32 num, UINT8 size);
 


### PR DESCRIPTION
Fixes the help command outputting fixed point numbers that are not readable to the average person.
This was because if a variable was a float, eg. `fov`, the fixed point numbers used to represent it were not being converted back into normal integers leading to an output that looks kind of like this:

```
 $help fov
Variable fov:
  flags: AUTOSAVE FLOAT ACTION 
  range from 327680 to 11730944
 Current value: 5898240
```
Now if you convert all those numbers to integers by shifting right by `FRACBITS`  You will get 5-179 for the range and 90 for the current value and by properly converting those numbers you get something more like this

```
$help fov
Variable fov:
  flags: AUTOSAVE FLOAT ACTION 
  range from 5 to 179
 Current value: 90
```
Which is obviously way more readable to the average person. 
As a bonus this patch also strips any trailing zeroes from CVars as they are unnecessary
