### PR TITLE
Speedup Filesearch 

### DIFF
--- a/src/d_netfil.c
+++ b/src/d_netfil.c
@@ -1179,7 +1179,7 @@ filestatus_t findfile(char *filename, const UINT8 *wantedmd5sum, boolean complet
 		if (cv_addons_option.value == 3 && *cv_addons_folder.string != '\0')
 		{
 			// first, check any custom directory if specified
-			homecheck = filesearch(filename, cv_addons_folder.string, wantedmd5sum, completepath, 10, false);
+			homecheck = filesearch(filename, cv_addons_folder.string, wantedmd5sum, completepath, 10);
 
 			if (homecheck == FS_FOUND) // we found the file, so return that we have :)
 				return FS_FOUND;
@@ -1189,7 +1189,7 @@ filestatus_t findfile(char *filename, const UINT8 *wantedmd5sum, boolean complet
 		}
 
 		// next, check "DOWNLOAD" directory
-		homecheck = filesearch(filename, "DOWNLOAD", wantedmd5sum, completepath, 10, false);
+		homecheck = filesearch(filename, "DOWNLOAD", wantedmd5sum, completepath, 10);
 
 		if (homecheck == FS_FOUND) // we found the file, so return that we have :)
 			return FS_FOUND;
@@ -1198,7 +1198,7 @@ filestatus_t findfile(char *filename, const UINT8 *wantedmd5sum, boolean complet
 		// if not found at all, just move on without doing anything
 
 		// next, check "addons" directory
-		homecheck = filesearch(filename, "addons", wantedmd5sum, completepath, 10, false);
+		homecheck = filesearch(filename, "addons", wantedmd5sum, completepath, 10);
 
 		if (homecheck == FS_FOUND) // we found the file, so return that we have :)
 			return FS_FOUND;
@@ -1208,7 +1208,7 @@ filestatus_t findfile(char *filename, const UINT8 *wantedmd5sum, boolean complet
 	}
 
 	// next, check SRB2's "home" directory
-	homecheck = filesearch(filename, srb2home, wantedmd5sum, completepath, 10, true);
+	homecheck = filesearch(filename, srb2home, wantedmd5sum, completepath, 10);
 
 	if (homecheck == FS_FOUND) // we found the file, so return that we have :)
 		return FS_FOUND;
@@ -1217,7 +1217,7 @@ filestatus_t findfile(char *filename, const UINT8 *wantedmd5sum, boolean complet
 	// if not found at all, just move on without doing anything
 
 	// next, check SRB2's "path" directory
-	homecheck = filesearch(filename, srb2path, wantedmd5sum, completepath, 10, true);
+	homecheck = filesearch(filename, srb2path, wantedmd5sum, completepath, 10);
 
 	if (homecheck == FS_FOUND) // we found the file, so return that we have :)
 		return FS_FOUND;
@@ -1226,7 +1226,7 @@ filestatus_t findfile(char *filename, const UINT8 *wantedmd5sum, boolean complet
 	// if not found at all, just move on without doing anything
 
 	// finally check "." directory
-	homecheck = filesearch(filename, ".", wantedmd5sum, completepath, 10, true);
+	homecheck = filesearch(filename, ".", wantedmd5sum, completepath, 10);
 
 	if (homecheck != FS_NOTFOUND) // if not found this time, fall back on the below return statement
 		return homecheck; // otherwise return the result we got

--- a/src/d_netfil.c
+++ b/src/d_netfil.c
@@ -1173,28 +1173,32 @@ filestatus_t findfile(char *filename, const UINT8 *wantedmd5sum, boolean complet
 	filestatus_t homecheck; // store result of last file search
 	boolean badmd5 = false; // store whether md5 was bad from either of the first two searches (if nothing was found in the third)
 
-	// first, check SRB2's "home" directory
-	homecheck = filesearch(filename, srb2home, wantedmd5sum, completepath, 10);
-
-	if (homecheck == FS_FOUND) // we found the file, so return that we have :)
-		return FS_FOUND;
-	else if (homecheck == FS_MD5SUMBAD) // file has a bad md5; move on and look for a file with the right md5
-		badmd5 = true;
-	// if not found at all, just move on without doing anything
-
-	// next, check SRB2's "path" directory
-	homecheck = filesearch(filename, srb2path, wantedmd5sum, completepath, 10);
-
-	if (homecheck == FS_FOUND) // we found the file, so return that we have :)
-		return FS_FOUND;
-	else if (homecheck == FS_MD5SUMBAD) // file has a bad md5; move on and look for a file with the right md5
-		badmd5 = true;
-	// if not found at all, just move on without doing anything
-
-	if (cv_addons_option.value == 3 && *cv_addons_folder.string != '\0')
+	// skip for startup, our mainwads wont be in there
+	if (loaded_config)
 	{
-		// next, check any custom directory if specified
-		homecheck = filesearch(filename, cv_addons_folder.string, wantedmd5sum, completepath, 10);
+		if (cv_addons_option.value == 3 && *cv_addons_folder.string != '\0')
+		{
+			// first, check any custom directory if specified
+			homecheck = filesearch(filename, cv_addons_folder.string, wantedmd5sum, completepath, 10, false);
+
+			if (homecheck == FS_FOUND) // we found the file, so return that we have :)
+				return FS_FOUND;
+			else if (homecheck == FS_MD5SUMBAD) // file has a bad md5; move on and look for a file with the right md5
+				badmd5 = true;
+			// if not found at all, just move on without doing anything
+		}
+
+		// next, check "DOWNLOAD" directory
+		homecheck = filesearch(filename, "DOWNLOAD", wantedmd5sum, completepath, 10, false);
+
+		if (homecheck == FS_FOUND) // we found the file, so return that we have :)
+			return FS_FOUND;
+		else if (homecheck == FS_MD5SUMBAD) // file has a bad md5; move on and look for a file with the right md5
+			badmd5 = true;
+		// if not found at all, just move on without doing anything
+
+		// next, check "addons" directory
+		homecheck = filesearch(filename, "addons", wantedmd5sum, completepath, 10, false);
 
 		if (homecheck == FS_FOUND) // we found the file, so return that we have :)
 			return FS_FOUND;
@@ -1203,8 +1207,26 @@ filestatus_t findfile(char *filename, const UINT8 *wantedmd5sum, boolean complet
 		// if not found at all, just move on without doing anything
 	}
 
+	// next, check SRB2's "home" directory
+	homecheck = filesearch(filename, srb2home, wantedmd5sum, completepath, 10, true);
+
+	if (homecheck == FS_FOUND) // we found the file, so return that we have :)
+		return FS_FOUND;
+	else if (homecheck == FS_MD5SUMBAD) // file has a bad md5; move on and look for a file with the right md5
+		badmd5 = true;
+	// if not found at all, just move on without doing anything
+
+	// next, check SRB2's "path" directory
+	homecheck = filesearch(filename, srb2path, wantedmd5sum, completepath, 10, true);
+
+	if (homecheck == FS_FOUND) // we found the file, so return that we have :)
+		return FS_FOUND;
+	else if (homecheck == FS_MD5SUMBAD) // file has a bad md5; move on and look for a file with the right md5
+		badmd5 = true;
+	// if not found at all, just move on without doing anything
+
 	// finally check "." directory
-	homecheck = filesearch(filename, ".", wantedmd5sum, completepath, 10);
+	homecheck = filesearch(filename, ".", wantedmd5sum, completepath, 10, true);
 
 	if (homecheck != FS_NOTFOUND) // if not found this time, fall back on the below return statement
 		return homecheck; // otherwise return the result we got

--- a/src/dedicated/i_system.c
+++ b/src/dedicated/i_system.c
@@ -1899,7 +1899,7 @@ static const char *searchWad(const char *searchDir)
 	filestatus_t fstemp;
 
 	strcpy(tempsw, WADKEYWORD1);
-	fstemp = filesearch(tempsw, searchDir, NULL, true, 20, true);
+	fstemp = filesearch(tempsw, searchDir, NULL, true, 20);
 	if (fstemp == FS_FOUND)
 	{
 		pathonly(tempsw);
@@ -1907,7 +1907,7 @@ static const char *searchWad(const char *searchDir)
 	}
 
 	strcpy(tempsw, WADKEYWORD2);
-	fstemp = filesearch(tempsw, searchDir, NULL, true, 20, true);
+	fstemp = filesearch(tempsw, searchDir, NULL, true, 20);
 	if (fstemp == FS_FOUND)
 	{
 		pathonly(tempsw);

--- a/src/dedicated/i_system.c
+++ b/src/dedicated/i_system.c
@@ -1899,7 +1899,7 @@ static const char *searchWad(const char *searchDir)
 	filestatus_t fstemp;
 
 	strcpy(tempsw, WADKEYWORD1);
-	fstemp = filesearch(tempsw,searchDir,NULL,true,20);
+	fstemp = filesearch(tempsw, searchDir, NULL, true, 20, true);
 	if (fstemp == FS_FOUND)
 	{
 		pathonly(tempsw);
@@ -1907,7 +1907,7 @@ static const char *searchWad(const char *searchDir)
 	}
 
 	strcpy(tempsw, WADKEYWORD2);
-	fstemp = filesearch(tempsw, searchDir, NULL, true, 20);
+	fstemp = filesearch(tempsw, searchDir, NULL, true, 20, true);
 	if (fstemp == FS_FOUND)
 	{
 		pathonly(tempsw);

--- a/src/filesrch.c
+++ b/src/filesrch.c
@@ -388,6 +388,7 @@ filestatus_t filesearch(char *filename, const char *startpath, const UINT8 *want
 	int depthleft = maxsearchdepth;
 	char searchpath[1024];
 	size_t *searchpathindex;
+	boolean folderchanged = true;
 
 	dirhandle = (DIR**)malloc(maxsearchdepth * sizeof(DIR*));
 	searchpathindex = (size_t *)malloc(maxsearchdepth * sizeof(size_t));
@@ -422,6 +423,7 @@ filestatus_t filesearch(char *filename, const char *startpath, const UINT8 *want
 		if (!dent)
 		{
 			closedir(dirhandle[depthleft++]);
+			folderchanged = true;
 			continue;
 		}
 
@@ -435,7 +437,7 @@ filestatus_t filesearch(char *filename, const char *startpath, const UINT8 *want
 		}
 
 		// skip some folders that wont have addons in them
-		if (skipexclude)
+		if (skipexclude && folderchanged)
 		{
 			boolean skipfolder = false;
 
@@ -457,6 +459,7 @@ filestatus_t filesearch(char *filename, const char *startpath, const UINT8 *want
 			if (skipfolder)
 			{
 				closedir(dirhandle[depthleft++]);
+				folderchanged = true;
 				continue;
 			}
 		}
@@ -503,6 +506,8 @@ filestatus_t filesearch(char *filename, const char *startpath, const UINT8 *want
 
 			searchpath[searchpathindex[depthleft]-1] = PATHSEP[0];
 			searchpath[searchpathindex[depthleft]] = 0;
+			folderchanged = true;
+			continue;
 		}
 		else if (!strcasecmp(searchname, dent->d_name))
 		{
@@ -523,6 +528,8 @@ filestatus_t filesearch(char *filename, const char *startpath, const UINT8 *want
 					break;
 			}
 		}
+
+		folderchanged = false;
 	}
 
 	for (; depthleft < maxsearchdepth; closedir(dirhandle[depthleft++]));

--- a/src/filesrch.c
+++ b/src/filesrch.c
@@ -484,9 +484,11 @@ filestatus_t filesearch(char *filename, const char *startpath, const UINT8 *want
 		// FIXME: should we also follow symlinks?
 		if ((dent->d_type == DT_DIR && depthleft) || (dent->d_type == DT_LNK && depthleft))
 #else
-		if (stat(searchpath, &fsstat) < 0) // do we want to follow symlinks? if not: change it to lstat
+		// if we wanna follow symlinks we can check with FILE_ATTRIBUTE_REPARSE_POINT
+		DWORD fileattr = GetFileAttributes(searchpath);
+		if (fileattr == INVALID_FILE_ATTRIBUTES)
 			; // was the file (re)moved? can't stat it
-		else if (S_ISDIR(fsstat.st_mode) && depthleft)
+		else if ((fileattr & FILE_ATTRIBUTE_DIRECTORY) && depthleft)
 #endif
 		{
 			searchpathindex[--depthleft] = strlen(searchpath) + 1;

--- a/src/filesrch.c
+++ b/src/filesrch.c
@@ -477,7 +477,7 @@ filestatus_t filesearch(char *filename, const char *startpath, const UINT8 *want
 
 				for (; *path != NULL; path++)
 				{
-					if (strcasecmp(*path, dent->d_name))
+					if (strcasecmp(*path, dent->d_name) == 0)
 					{
 						skipfolder = true;
 						break;

--- a/src/filesrch.c
+++ b/src/filesrch.c
@@ -734,30 +734,44 @@ boolean preparefilemenu(boolean samedepth, boolean replayhut)
 		if (!dent)
 			break;
 		else if (dent->d_name[0]=='.' &&
-				(dent->d_name[1]=='\0' ||
-					(dent->d_name[1]=='.' &&
-						dent->d_name[2]=='\0')))
+					(dent->d_name[1]=='\0' ||
+						(dent->d_name[1]=='.' &&
+							dent->d_name[2]=='\0')))
 			continue; // we don't want to scan uptree
 
 		strcpy(&menupath[menupathindex[menudepthleft]],dent->d_name);
 
-		if (stat(menupath,&fsstat) < 0) // do we want to follow symlinks? if not: change it to lstat
+#if defined(__linux__) || defined(__FreeBSD__)
+		if (stat(menupath, &fsstat) < 0)
+#else
+		// if we wanna follow symlinks we can check with FILE_ATTRIBUTE_REPARSE_POINT
+		DWORD fileattr = GetFileAttributes(searchpath);
+		if (fileattr == INVALID_FILE_ATTRIBUTES)
+#endif
 			; // was the file (re)moved? can't stat it
 		else // is a file or directory
 		{
+#if defined(__linux__) || defined(__FreeBSD__)
 			if (!S_ISDIR(fsstat.st_mode)) // file
+#else
+			if (!(fileattr & FILE_ATTRIBUTE_DIRECTORY))
+#endif
 			{
 				size_t len = strlen(dent->d_name)+1;
 				if (replayhut)
 				{
-					if (strcasecmp(".lmp", dent->d_name+len-5)) continue; // Not a replay
+					if (strcasecmp(".lmp", dent->d_name+len-5))
+						continue; // Not a replay
 				}
 				else if (!cv_addons_showall.value)
 				{
 					UINT8 ext;
 					for (ext = 0; ext < NUM_EXT_TABLE; ext++)
-						if (!strcasecmp(exttable[ext]+1, dent->d_name+len-(exttable[ext][0]))) break; // extension comparison
-					if (ext == NUM_EXT_TABLE) continue; // not an addfile-able (or exec-able) file
+						if (!strcasecmp(exttable[ext]+1, dent->d_name+len-(exttable[ext][0])))
+							break; // extension comparison
+
+					if (ext == NUM_EXT_TABLE)
+						continue; // not an addfile-able (or exec-able) file
 				}
 			}
 			else // directory
@@ -802,14 +816,20 @@ boolean preparefilemenu(boolean samedepth, boolean replayhut)
 		if (!dent)
 			break;
 		else if (dent->d_name[0]=='.' &&
-				(dent->d_name[1]=='\0' ||
-					(dent->d_name[1]=='.' &&
-						dent->d_name[2]=='\0')))
+					(dent->d_name[1]=='\0' ||
+						(dent->d_name[1]=='.' &&
+							dent->d_name[2]=='\0')))
 			continue; // we don't want to scan uptree
 
 		strcpy(&menupath[menupathindex[menudepthleft]],dent->d_name);
 
-		if (stat(menupath,&fsstat) < 0) // do we want to follow symlinks? if not: change it to lstat
+#if defined(__linux__) || defined(__FreeBSD__)
+		if (stat(menupath, &fsstat) < 0)
+#else
+		// if we wanna follow symlinks we can check with FILE_ATTRIBUTE_REPARSE_POINT
+		DWORD fileattr = GetFileAttributes(searchpath);
+		if (fileattr == INVALID_FILE_ATTRIBUTES)
+#endif
 			; // was the file (re)moved? can't stat it
 		else // is a file or directory
 		{
@@ -818,20 +838,31 @@ boolean preparefilemenu(boolean samedepth, boolean replayhut)
 			UINT8 ext = EXT_FOLDER;
 			UINT8 folder;
 
+#if defined(__linux__) || defined(__FreeBSD__)
 			if (!S_ISDIR(fsstat.st_mode)) // file
+#else
+			if (!(fileattr & FILE_ATTRIBUTE_DIRECTORY))
+#endif
 			{
-				if (!((numfolders+pos) < sizecoredirmenu)) continue; // crash prevention
+				if (!((numfolders+pos) < sizecoredirmenu))
+					continue; // crash prevention
 
 				if (replayhut)
 				{
-					if (strcasecmp(".lmp", dent->d_name+len-5)) continue; // Not a replay
+					if (strcasecmp(".lmp", dent->d_name+len-5))
+						continue; // Not a replay
+
 					ext = EXT_TXT; // This isn't used anywhere but better safe than sorry for messing with this...
 				}
 				else
 				{
 					for (; ext < NUM_EXT_TABLE; ext++)
-						if (!strcasecmp(exttable[ext]+1, dent->d_name+len-(exttable[ext][0]))) break; // extension comparison
-					if (ext == NUM_EXT_TABLE && !cv_addons_showall.value) continue; // not an addfile-able (or exec-able) file
+						if (!strcasecmp(exttable[ext]+1, dent->d_name+len-(exttable[ext][0])))
+							break; // extension comparison
+
+					if (ext == NUM_EXT_TABLE && !cv_addons_showall.value)
+						continue; // not an addfile-able (or exec-able) file
+
 					ext += EXT_START; // moving to be appropriate position
 
 					if (ext >= EXT_LOADSTART)
@@ -848,6 +879,7 @@ boolean preparefilemenu(boolean samedepth, boolean replayhut)
 
 							if (strcmp(dent->d_name, filenamebuf[i]))
 								continue;
+
 							if (cv_addons_md5.value && !checkfilemd5(menupath, wadfiles[i]->md5sum))
 								continue;
 
@@ -874,9 +906,11 @@ boolean preparefilemenu(boolean samedepth, boolean replayhut)
 
 			if (!(temp = Z_Malloc((len+DIR_STRING+folder) * sizeof (char), PU_STATIC, NULL)))
 				I_Error("preparefilemenu(): could not create file entry.");
+
 			temp[DIR_TYPE] = ext;
 			temp[DIR_LEN] = (UINT8)(len);
 			strlcpy(temp+DIR_STRING, dent->d_name, len);
+
 			if (folder)
 			{
 				strcpy(temp+len, PATHSEP);

--- a/src/filesrch.c
+++ b/src/filesrch.c
@@ -745,7 +745,7 @@ boolean preparefilemenu(boolean samedepth, boolean replayhut)
 		if (stat(menupath, &fsstat) < 0)
 #else
 		// if we wanna follow symlinks we can check with FILE_ATTRIBUTE_REPARSE_POINT
-		DWORD fileattr = GetFileAttributes(searchpath);
+		DWORD fileattr = GetFileAttributes(menupath);
 		if (fileattr == INVALID_FILE_ATTRIBUTES)
 #endif
 			; // was the file (re)moved? can't stat it
@@ -827,7 +827,7 @@ boolean preparefilemenu(boolean samedepth, boolean replayhut)
 		if (stat(menupath, &fsstat) < 0)
 #else
 		// if we wanna follow symlinks we can check with FILE_ATTRIBUTE_REPARSE_POINT
-		DWORD fileattr = GetFileAttributes(searchpath);
+		DWORD fileattr = GetFileAttributes(menupath);
 		if (fileattr == INVALID_FILE_ATTRIBUTES)
 #endif
 			; // was the file (re)moved? can't stat it

--- a/src/filesrch.c
+++ b/src/filesrch.c
@@ -12,7 +12,6 @@
 ///	        FS_MD5SUMBAD;
 ///	        FS_FOUND
 
-#include "d_main.h"
 #include <stdio.h>
 #ifdef __GNUC__
 #include <dirent.h>

--- a/src/filesrch.c
+++ b/src/filesrch.c
@@ -341,6 +341,7 @@ char *refreshdirname = NULL;
 // direrror is set if there was an error.
 INT32 pathisdirectory(const char *path)
 {
+#ifndef _WIN32
 	struct stat fsstat;
 
 	if (stat(path, &fsstat) < 0)
@@ -348,7 +349,21 @@ INT32 pathisdirectory(const char *path)
 		return -1;
 	}
 	else if (S_ISDIR(fsstat.st_mode))
+	{
 		return 1;
+	}
+
+#else
+	DWORD fileattr = GetFileAttributes(path);
+	if (fileattr == INVALID_FILE_ATTRIBUTES)
+	{
+		return -1;
+	}
+	else if (fileattr & FILE_ATTRIBUTE_DIRECTORY)
+	{
+		return 1;
+	}
+#endif
 
 	return 0;
 }

--- a/src/filesrch.c
+++ b/src/filesrch.c
@@ -381,7 +381,9 @@ filestatus_t filesearch(char *filename, const char *startpath, const UINT8 *want
 	filestatus_t retval = FS_NOTFOUND;
 	DIR **dirhandle;
 	struct dirent *dent;
+#ifndef _WIN32
 	struct stat fsstat;
+#endif
 	int found = 0;
 	char *searchname;
 	int depthleft = maxsearchdepth;
@@ -485,12 +487,16 @@ filestatus_t filesearch(char *filename, const char *startpath, const UINT8 *want
 		// Linux and FreeBSD has a special field for file type on dirent, so use that to speed up lookups.
 		// FIXME: should we also follow symlinks?
 		if ((dent->d_type == DT_DIR && depthleft) || (dent->d_type == DT_LNK && depthleft))
-#else
+#elif defined (_WIN32)
 		// if we wanna follow symlinks we can check with FILE_ATTRIBUTE_REPARSE_POINT
 		DWORD fileattr = GetFileAttributes(searchpath);
 		if (fileattr == INVALID_FILE_ATTRIBUTES)
 			; // was the file (re)moved? can't stat it
 		else if ((fileattr & FILE_ATTRIBUTE_DIRECTORY) && depthleft)
+#else
+		if (stat(searchpath,&fsstat) < 0) // do we want to follow symlinks? if not: change it to lstat
+			; // was the file (re)moved? can't stat it
+		else if (S_ISDIR(fsstat.st_mode) && depthleft)
 #endif
 		{
 			searchpathindex[--depthleft] = strlen(searchpath) + 1;
@@ -704,7 +710,9 @@ boolean preparefilemenu(boolean samedepth, boolean replayhut)
 {
 	DIR *dirhandle;
 	struct dirent *dent;
+#ifndef _WIN32
 	struct stat fsstat;
+#endif
 	size_t pos = 0, folderpos = 0, numfolders = 0;
 	char *tempname = NULL;
 
@@ -747,7 +755,7 @@ boolean preparefilemenu(boolean samedepth, boolean replayhut)
 
 		strcpy(&menupath[menupathindex[menudepthleft]],dent->d_name);
 
-#if defined(__linux__) || defined(__FreeBSD__)
+#ifndef _WIN32
 		if (stat(menupath, &fsstat) < 0)
 #else
 		// if we wanna follow symlinks we can check with FILE_ATTRIBUTE_REPARSE_POINT
@@ -757,7 +765,7 @@ boolean preparefilemenu(boolean samedepth, boolean replayhut)
 			; // was the file (re)moved? can't stat it
 		else // is a file or directory
 		{
-#if defined(__linux__) || defined(__FreeBSD__)
+#ifndef _WIN32
 			if (!S_ISDIR(fsstat.st_mode)) // file
 #else
 			if (!(fileattr & FILE_ATTRIBUTE_DIRECTORY))
@@ -829,7 +837,7 @@ boolean preparefilemenu(boolean samedepth, boolean replayhut)
 
 		strcpy(&menupath[menupathindex[menudepthleft]],dent->d_name);
 
-#if defined(__linux__) || defined(__FreeBSD__)
+#ifndef _WIN32
 		if (stat(menupath, &fsstat) < 0)
 #else
 		// if we wanna follow symlinks we can check with FILE_ATTRIBUTE_REPARSE_POINT
@@ -844,7 +852,7 @@ boolean preparefilemenu(boolean samedepth, boolean replayhut)
 			UINT8 ext = EXT_FOLDER;
 			UINT8 folder;
 
-#if defined(__linux__) || defined(__FreeBSD__)
+#ifndef _WIN32
 			if (!S_ISDIR(fsstat.st_mode)) // file
 #else
 			if (!(fileattr & FILE_ATTRIBUTE_DIRECTORY))

--- a/src/filesrch.c
+++ b/src/filesrch.c
@@ -369,27 +369,15 @@ INT32 pathisdirectory(const char *path)
 }
 
 // skip those folders, they will not have any addons
-#ifdef _WIN32
 static const char *exclude_paths[] = {
-	"\\logs\\",
-	"\\luafiles\\",
-	"\\replay\\",
-	"\\mdls\\",
-	"\\gifs\\",
-	"\\screenshots\\",
+	"logs",
+	"luafiles",
+	"replay",
+	"mdls",
+	"gifs",
+	"screenshots",
 	NULL
 };
-#else
-static const char *exclude_paths[] = {
-	"/logs/",
-	"/luafiles/",
-	"/replay/",
-	"/mdls/",
-	"/gifs/",
-	"/screenshots/",
-	NULL
-};
-#endif
 
 filestatus_t filesearch(char *filename, const char *startpath, const UINT8 *wantedmd5sum, boolean completepath, int maxsearchdepth)
 {
@@ -404,7 +392,6 @@ filestatus_t filesearch(char *filename, const char *startpath, const UINT8 *want
 	int depthleft = maxsearchdepth;
 	char searchpath[1024];
 	size_t *searchpathindex;
-	boolean folderchanged = true; // tells us if we changed folders during traversal
 
 	dirhandle = (DIR**)malloc(maxsearchdepth * sizeof(DIR*));
 	searchpathindex = (size_t *)malloc(maxsearchdepth * sizeof(size_t));
@@ -439,7 +426,6 @@ filestatus_t filesearch(char *filename, const char *startpath, const UINT8 *want
 		if (!dent)
 		{
 			closedir(dirhandle[depthleft++]);
-			folderchanged = true;
 			continue;
 		}
 
@@ -452,103 +438,92 @@ filestatus_t filesearch(char *filename, const char *startpath, const UINT8 *want
 			continue;
 		}
 
-		// skip some folders that wont have addons in them
-		if (folderchanged)
-		{
-			boolean skipfolder = false;
-
-			for (const char **path = exclude_paths; *path != NULL; path++)
-			{
-				if (**path == '\0')
-					continue;
-#ifdef _WIN32
-				if (strstr(searchpath, *path)) // windows doesent care if lower or uppercase
-#else
-				if (strcasestr(searchpath, *path))
-#endif
-				{
-					skipfolder = true;
-					break;
-				}
-			}
-
-			if (skipfolder)
-			{
-				closedir(dirhandle[depthleft++]);
-				folderchanged = true;
-				continue;
-			}
-		}
-
 		// okay, now we actually want searchpath to incorporate d_name
 		strcpy(&searchpath[searchpathindex[depthleft]], dent->d_name);
 
-#if defined(__linux__) || defined(__FreeBSD__)
-		if (dent->d_type == DT_UNKNOWN && lstat(searchpath, &fsstat) == 0)
-		{
-			if (S_ISDIR(fsstat.st_mode))
+#if defined(__linux__) || defined(__FreeBSD__) || defined(__OpenBSD__)
+		if (dent->d_type == DT_UNKNOWN || dent->d_type == DT_LNK)
+			if (stat(searchpath, &fsstat) == 0 && S_ISDIR(fsstat.st_mode))
 				dent->d_type = DT_DIR;
-			else if (S_ISLNK(fsstat.st_mode))
-				dent->d_type = DT_LNK;
-		}
-
-		// Symlinks aren't always directory symlinks. Dunno if this would resolve recursive
-		// symlinks, but i think stat already does that
-		if (dent->d_type == DT_LNK && stat(searchpath, &fsstat) == 0 && !S_ISDIR(fsstat.st_mode))
-		{
-			dent->d_type = DT_UNKNOWN;
-		}
 
 		// Linux and FreeBSD has a special field for file type on dirent, so use that to speed up lookups.
-		if ((dent->d_type == DT_DIR && depthleft) || (dent->d_type == DT_LNK && depthleft))
+		if (dent->d_type == DT_DIR)
 #elif defined (_WIN32)
 		// if we wanna follow symlinks we can check with FILE_ATTRIBUTE_REPARSE_POINT
 		DWORD fileattr = GetFileAttributes(searchpath);
 		if (fileattr == INVALID_FILE_ATTRIBUTES)
-			; // was the file (re)moved? can't stat it
-		else if ((fileattr & FILE_ATTRIBUTE_DIRECTORY) && depthleft)
+			continue; // was the file (re)moved? can't stat it
+
+		if (fileattr & FILE_ATTRIBUTE_DIRECTORY)
 #else
 		if (stat(searchpath,&fsstat) < 0) // do we want to follow symlinks? if not: change it to lstat
-			; // was the file (re)moved? can't stat it
-		else if (S_ISDIR(fsstat.st_mode) && depthleft)
+			continue; // was the file (re)moved? can't stat it
+
+		if (S_ISDIR(fsstat.st_mode))
 #endif
 		{
-			searchpathindex[--depthleft] = strlen(searchpath) + 1;
-			dirhandle[depthleft] = opendir(searchpath);
+			// I am a folder!
 
-			if (!dirhandle[depthleft])
+			if (!depthleft)
+				continue; // No additional folder delving permitted...
+
+			const char **path = exclude_paths;
+
+			if (depthleft == maxsearchdepth-1)
 			{
-				// can't open it... maybe no read-permissions
-				// go back to previous dir
-				depthleft++;
+				// When we're at the root of the search, we exclude certain folders.
+
+				boolean skipfolder = false;
+
+				for (; *path != NULL; path++)
+				{
+					if (strcasecmp(*path, dent->d_name))
+					{
+						skipfolder = true;
+						break;
+					}
+				}
+
+				if (skipfolder)
+				{
+					continue;
+				}
 			}
 
-			searchpath[searchpathindex[depthleft]-1] = PATHSEP[0];
-			searchpath[searchpathindex[depthleft]] = 0;
-			folderchanged = true;
+			if (strcasecmp(".git", dent->d_name) // sanity if you're weird like me
+				&& (dirhandle[depthleft-1] = opendir(searchpath)) != NULL)
+			{
+				// Got read permissions!
+				searchpathindex[--depthleft] = strlen(searchpath) + 1;
+
+				searchpath[searchpathindex[depthleft]-1] = PATHSEP[0];
+				searchpath[searchpathindex[depthleft]] = 0;
+			}
+
 			continue;
 		}
-		else if (!strcasecmp(searchname, dent->d_name))
-		{
-			switch (checkfilemd5(searchpath, wantedmd5sum))
-			{
-				case FS_FOUND:
-					if (completepath)
-						strcpy(filename, searchpath);
-					else
-						strcpy(filename, dent->d_name);
-					retval = FS_FOUND;
-					found = 1;
-					break;
-				case FS_MD5SUMBAD:
-					retval = FS_MD5SUMBAD;
-					break;
-				default: // prevent some compiler warnings
-					break;
-			}
-		}
 
-		folderchanged = false;
+		// I am a file!
+
+		if (strcasecmp(searchname, dent->d_name))
+			continue; // Not what we're looking for!
+
+		switch (checkfilemd5(searchpath, wantedmd5sum))
+		{
+			case FS_FOUND:
+				if (completepath)
+					strcpy(filename, searchpath);
+				else
+					strcpy(filename, dent->d_name);
+				retval = FS_FOUND;
+				found = 1;
+				break;
+			case FS_MD5SUMBAD:
+				retval = FS_MD5SUMBAD;
+				break;
+			default: // prevent some compiler warnings
+				break;
+		}
 	}
 
 	for (; depthleft < maxsearchdepth; closedir(dirhandle[depthleft++]));

--- a/src/filesrch.c
+++ b/src/filesrch.c
@@ -391,7 +391,7 @@ static const char *exclude_paths[] = {
 };
 #endif
 
-filestatus_t filesearch(char *filename, const char *startpath, const UINT8 *wantedmd5sum, boolean completepath, int maxsearchdepth, boolean skipexclude)
+filestatus_t filesearch(char *filename, const char *startpath, const UINT8 *wantedmd5sum, boolean completepath, int maxsearchdepth)
 {
 	filestatus_t retval = FS_NOTFOUND;
 	DIR **dirhandle;
@@ -404,7 +404,7 @@ filestatus_t filesearch(char *filename, const char *startpath, const UINT8 *want
 	int depthleft = maxsearchdepth;
 	char searchpath[1024];
 	size_t *searchpathindex;
-	boolean folderchanged = true;
+	boolean folderchanged = true; // tells us if we changed folders during traversal
 
 	dirhandle = (DIR**)malloc(maxsearchdepth * sizeof(DIR*));
 	searchpathindex = (size_t *)malloc(maxsearchdepth * sizeof(size_t));
@@ -453,7 +453,7 @@ filestatus_t filesearch(char *filename, const char *startpath, const UINT8 *want
 		}
 
 		// skip some folders that wont have addons in them
-		if (skipexclude && folderchanged)
+		if (folderchanged)
 		{
 			boolean skipfolder = false;
 
@@ -500,7 +500,6 @@ filestatus_t filesearch(char *filename, const char *startpath, const UINT8 *want
 		}
 
 		// Linux and FreeBSD has a special field for file type on dirent, so use that to speed up lookups.
-		// FIXME: should we also follow symlinks?
 		if ((dent->d_type == DT_DIR && depthleft) || (dent->d_type == DT_LNK && depthleft))
 #elif defined (_WIN32)
 		// if we wanna follow symlinks we can check with FILE_ATTRIBUTE_REPARSE_POINT

--- a/src/filesrch.c
+++ b/src/filesrch.c
@@ -12,6 +12,7 @@
 ///	        FS_MD5SUMBAD;
 ///	        FS_FOUND
 
+#include "d_main.h"
 #include <stdio.h>
 #ifdef __GNUC__
 #include <dirent.h>
@@ -353,33 +354,57 @@ INT32 pathisdirectory(const char *path)
 	return 0;
 }
 
-filestatus_t filesearch(char *filename, const char *startpath, const UINT8 *wantedmd5sum, boolean completepath, int maxsearchdepth)
+// skip those folders, they will not have any addons
+#ifdef _WIN32
+static const char *exclude_paths[] = {
+	"\\logs\\",
+	"\\luafiles\\",
+	"\\replay\\",
+	"\\mdls\\",
+	"\\gifs\\",
+	"\\screenshots\\",
+	NULL
+};
+#else
+static const char *exclude_paths[] = {
+	"/logs/",
+	"/luafiles/",
+	"/replay/",
+	"/mdls/",
+	"/gifs/",
+	"/screenshots/",
+	NULL
+};
+#endif
+
+filestatus_t filesearch(char *filename, const char *startpath, const UINT8 *wantedmd5sum, boolean completepath, int maxsearchdepth, boolean skipexclude)
 {
 	filestatus_t retval = FS_NOTFOUND;
 	DIR **dirhandle;
 	struct dirent *dent;
 	struct stat fsstat;
 	int found = 0;
-	char *searchname = strdup(filename);
+	char *searchname;
 	int depthleft = maxsearchdepth;
 	char searchpath[1024];
 	size_t *searchpathindex;
 
-	dirhandle = (DIR**) malloc(maxsearchdepth * sizeof(DIR*));
-	searchpathindex = (size_t *) malloc(maxsearchdepth * sizeof(size_t));
+	dirhandle = (DIR**)malloc(maxsearchdepth * sizeof(DIR*));
+	searchpathindex = (size_t *)malloc(maxsearchdepth * sizeof(size_t));
 
-	strcpy(searchpath,startpath);
+	strcpy(searchpath, startpath);
 	searchpathindex[--depthleft] = strlen(searchpath) + 1;
 
 	dirhandle[depthleft] = opendir(searchpath);
 
 	if (dirhandle[depthleft] == NULL)
 	{
-		free(searchname);
 		free(dirhandle);
 		free(searchpathindex);
 		return FS_NOTFOUND;
 	}
+
+	searchname = strdup(filename);
 
 	if (searchpath[searchpathindex[depthleft]-2] != PATHSEP[0])
 	{
@@ -409,6 +434,33 @@ filestatus_t filesearch(char *filename, const char *startpath, const UINT8 *want
 			continue;
 		}
 
+		// skip some folders that wont have addons in them
+		if (skipexclude)
+		{
+			boolean skipfolder = false;
+
+			for (const char **path = exclude_paths; *path != NULL; path++)
+			{
+				if (**path == '\0')
+					continue;
+#ifdef _WIN32
+				if (strstr(searchpath, *path)) // windows doesent care if lower or uppercase
+#else
+				if (strcasestr(searchpath, *path))
+#endif
+				{
+					skipfolder = true;
+					break;
+				}
+			}
+
+			if (skipfolder)
+			{
+				closedir(dirhandle[depthleft++]);
+				continue;
+			}
+		}
+
 		// okay, now we actually want searchpath to incorporate d_name
 		strcpy(&searchpath[searchpathindex[depthleft]], dent->d_name);
 
@@ -423,7 +475,7 @@ filestatus_t filesearch(char *filename, const char *startpath, const UINT8 *want
 
 		// Symlinks aren't always directory symlinks. Dunno if this would resolve recursive
 		// symlinks, but i think stat already does that
-		if (dent->d_type == DT_LNK && stat(searchpath,&fsstat) == 0 && !S_ISDIR(fsstat.st_mode))
+		if (dent->d_type == DT_LNK && stat(searchpath, &fsstat) == 0 && !S_ISDIR(fsstat.st_mode))
 		{
 			dent->d_type = DT_UNKNOWN;
 		}
@@ -432,7 +484,7 @@ filestatus_t filesearch(char *filename, const char *startpath, const UINT8 *want
 		// FIXME: should we also follow symlinks?
 		if ((dent->d_type == DT_DIR && depthleft) || (dent->d_type == DT_LNK && depthleft))
 #else
-		if (stat(searchpath,&fsstat) < 0) // do we want to follow symlinks? if not: change it to lstat
+		if (stat(searchpath, &fsstat) < 0) // do we want to follow symlinks? if not: change it to lstat
 			; // was the file (re)moved? can't stat it
 		else if (S_ISDIR(fsstat.st_mode) && depthleft)
 #endif

--- a/src/filesrch.h
+++ b/src/filesrch.h
@@ -24,14 +24,14 @@ extern consvar_t cv_addons_option, cv_addons_folder, cv_addons_md5, cv_addons_sh
 	\param	wantedmd5sum	want to check with MD5
 	\param	completepath	want to return the complete path of the file?
 	\param	maxsearchdepth	the max depth to search for the file
+	\param	skipexclude	when true this skips certain named folders
 
 	\return	filestatus_t
 
 
 */
 
-filestatus_t filesearch(char *filename, const char *startpath, const UINT8 *wantedmd5sum,
-	boolean completepath, int maxsearchdepth);
+filestatus_t filesearch(char *filename, const char *startpath, const UINT8 *wantedmd5sum, boolean completepath, int maxsearchdepth, boolean skipexclude);
 
 #define menudepth 20
 

--- a/src/filesrch.h
+++ b/src/filesrch.h
@@ -24,14 +24,13 @@ extern consvar_t cv_addons_option, cv_addons_folder, cv_addons_md5, cv_addons_sh
 	\param	wantedmd5sum	want to check with MD5
 	\param	completepath	want to return the complete path of the file?
 	\param	maxsearchdepth	the max depth to search for the file
-	\param	skipexclude	when true this skips certain named folders
 
 	\return	filestatus_t
 
 
 */
 
-filestatus_t filesearch(char *filename, const char *startpath, const UINT8 *wantedmd5sum, boolean completepath, int maxsearchdepth, boolean skipexclude);
+filestatus_t filesearch(char *filename, const char *startpath, const UINT8 *wantedmd5sum, boolean completepath, int maxsearchdepth);
 
 #define menudepth 20
 

--- a/src/sdl/i_system.cpp
+++ b/src/sdl/i_system.cpp
@@ -2486,7 +2486,7 @@ static const char *searchWad(const char *searchDir)
 	filestatus_t fstemp;
 
 	strcpy(tempsw, WADKEYWORD1);
-	fstemp = filesearch(tempsw, searchDir, NULL, true, 20, true);
+	fstemp = filesearch(tempsw, searchDir, NULL, true, 20);
 	if (fstemp == FS_FOUND)
 	{
 		pathonly(tempsw);

--- a/src/sdl/i_system.cpp
+++ b/src/sdl/i_system.cpp
@@ -2486,7 +2486,7 @@ static const char *searchWad(const char *searchDir)
 	filestatus_t fstemp;
 
 	strcpy(tempsw, WADKEYWORD1);
-	fstemp = filesearch(tempsw,searchDir,NULL,true,20);
+	fstemp = filesearch(tempsw, searchDir, NULL, true, 20, true);
 	if (fstemp == FS_FOUND)
 	{
 		pathonly(tempsw);

--- a/src/sdl/i_ttf.c
+++ b/src/sdl/i_ttf.c
@@ -58,7 +58,7 @@ static char *searchFont(const char *fontsearchDir)
 	filestatus_t fstemp;
 
 	strcpy(tempsw, FONTFILE);
-	fstemp = filesearch(tempsw, fontsearchDir, NULL, true, 20);
+	fstemp = filesearch(tempsw, fontsearchDir, NULL, true, 20, true);
 	if (fstemp == FS_FOUND)
 	{
 		return tempsw;

--- a/src/sdl/i_ttf.c
+++ b/src/sdl/i_ttf.c
@@ -58,7 +58,7 @@ static char *searchFont(const char *fontsearchDir)
 	filestatus_t fstemp;
 
 	strcpy(tempsw, FONTFILE);
-	fstemp = filesearch(tempsw, fontsearchDir, NULL, true, 20, true);
+	fstemp = filesearch(tempsw, fontsearchDir, NULL, true, 20);
 	if (fstemp == FS_FOUND)
 	{
 		return tempsw;


### PR DESCRIPTION
Currently the game checks almost ALL folders in no particular order for addons, this includes the log folder, replay folder etc., which _shouldnt_ ever contain addons.
This implements a folder "blacklist" of sorts, entirely skipping folders like these, and as a result, skipping checking potentially multiple thousand files for every single addon.
Ontop of this, after startup, findfile will now check the download, addons and custom addon folder first in line, since those are where addons reside by default

Windows also now uses the platform specific "GetFileAttributes" instead of stat (which is very slow as it seemingly has to emulate some POSIX behaviour), both for filesearch and preparefilemenu
Currently this ignores symlinks, need some more looking into if there is a need to follow those on windows

This MASSIVELY speeds up seeking for addons on Windows especially
even more if you got many replays, logfiles screenshots and such

Need a bit of testing to make sure this works as intended

Comparison before

https://github.com/user-attachments/assets/2923132b-aa13-4a12-9bcd-cf9c73be4e88

after:

https://github.com/user-attachments/assets/a0ca4d77-61cf-4cf5-a0ce-c5d68c88603a

(empty download/addons folder, many replays and logs)

Many thanks to Sunflower for testing this out!

