### PR TITLE
CURL cli args

### DIFF
--- a/src/Sourcefile
+++ b/src/Sourcefile
@@ -34,6 +34,7 @@ m_misc.c
 m_perfstats.c
 m_queue.c
 m_random.c
+m_curl.c
 mserv.c
 http-mserv.c
 qs22j.c

--- a/src/d_netfil.c
+++ b/src/d_netfil.c
@@ -35,7 +35,8 @@
 #endif
 
 #ifdef HAVE_CURL
-#include "curl/curl.h"
+#include <curl/curl.h>
+#include "m_curl.h"
 #endif
 
 #include "doomdef.h"
@@ -1400,6 +1401,8 @@ void CURLPrepareFile(const char* url, int dfilenum)
 		cc = curl_easy_setopt(http_handle, CURLOPT_PROGRESSFUNCTION, curlprogress_callback);
 		if (cc != CURLE_OK) I_OutputMsg("libcurl: %s\n", curl_errbuf);
 #endif
+
+		M_SetCURLArgs(http_handle, curl_errbuf);
 
 		curl_curfile->status = FS_DOWNLOADING;
 

--- a/src/d_protocol.c
+++ b/src/d_protocol.c
@@ -22,6 +22,7 @@
 
 #ifdef HAVE_CURL
 #include <curl/curl.h>
+#include "m_curl.h"
 #endif
 
 #include "doomdef.h"
@@ -257,8 +258,10 @@ void D_CreateProtocol(void)
 }
 
 #ifdef HAVE_CURL
+static char curl_errbuf[CURL_ERROR_SIZE];
 void D_DownloadReplay(const char *url, const char *path)
 {
+
 	FILE *fp = NULL;
 	CURL *curl;
 	CURLcode cc;
@@ -266,17 +269,29 @@ void D_DownloadReplay(const char *url, const char *path)
 	if (!curl)
 		I_Error("Unable to download replay. Error initializing CURL.");
 
+	cc = curl_easy_setopt(curl, CURLOPT_ERRORBUFFER, curl_errbuf);
+	if (cc != CURLE_OK) I_OutputMsg("libcurl: CURLOPT_ERRORBUFFER failed\n");
+	curl_errbuf[0] = 0x00;
+
 	fp = fopen(path, "wb");
 	CONS_Printf("REPLAY: URL: %s\n", url);
-	curl_easy_setopt(curl, CURLOPT_URL, url);
-       	curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, curlwrite_data);
-       	curl_easy_setopt(curl, CURLOPT_WRITEDATA, fp);
 
-       	cc = curl_easy_perform(curl);
+	cc = curl_easy_setopt(curl, CURLOPT_URL, url);
+	if (cc != CURLE_OK) I_OutputMsg("libcurl: %s\n", curl_errbuf);
+
+	cc = curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, curlwrite_data);
+	if (cc != CURLE_OK) I_OutputMsg("libcurl: %s\n", curl_errbuf);
+
+	cc = curl_easy_setopt(curl, CURLOPT_WRITEDATA, fp);
+	if (cc != CURLE_OK) I_OutputMsg("libcurl: %s\n", curl_errbuf);
+
+	M_SetCURLArgs(curl, curl_errbuf);
+
+	cc = curl_easy_perform(curl);
 	if (cc != CURLE_OK)
-		I_Error("Unable to download replay. URL gave response code %u.", cc);
+		I_Error("Unable to download replay. libcurl: %s.", curl_errbuf);
 
-       	curl_easy_cleanup(curl);
-       	fclose(fp);
+	curl_easy_cleanup(curl);
+	fclose(fp);
 }
 #endif

--- a/src/http-mserv.c
+++ b/src/http-mserv.c
@@ -16,6 +16,7 @@ Documentation available here.
 
 #ifdef HAVE_CURL
 #include <curl/curl.h>
+#include "m_curl.h"
 #endif
 
 #include "doomdef.h"
@@ -257,6 +258,8 @@ HMS_connect (const char *format, ...)
 
 	cc = curl_easy_setopt(curl, CURLOPT_WRITEDATA, buffer);
 	if (cc != CURLE_OK) I_OutputMsg("libcurl: %s\n", buffer->errbuf);
+
+	M_SetCURLArgs(curl, buffer->errbuf);
 
 	curl_free(quack_token);
 	free(url);

--- a/src/m_curl.c
+++ b/src/m_curl.c
@@ -1,0 +1,43 @@
+#include "m_curl.h"
+#include "doomtype.h"
+#include "i_system.h" // I_OutputMsg
+#include "m_argv.h" // M_CheckParm, M_GetNextParm
+
+static boolean curl_args_init = false;
+static const char *curl_args_proxy = NULL;
+static struct curl_slist *curl_args_headers = NULL;
+
+void M_SetCURLArgs(CURL *http_handle, char *curl_errbuf)
+{
+	CURLcode cc;
+
+	// Only need to do this once
+	if (!curl_args_init)
+	{
+		curl_args_init = true;
+
+		curl_args_proxy = M_CheckParm("-curl-proxy") ? M_GetNextParm() : NULL;
+
+		if (M_CheckParm("-curl-header"))
+		{
+			const char *param = NULL;
+
+			while ((param = M_GetNextParm()))
+			{
+				curl_args_headers = curl_slist_append(curl_args_headers, param);
+			}
+		}
+	}
+
+	if (curl_args_proxy)
+	{
+		cc = curl_easy_setopt(http_handle, CURLOPT_PROXY, curl_args_proxy);
+		if (cc != CURLE_OK) I_OutputMsg("libcurl: %s\n", curl_errbuf);
+	}
+
+	if (curl_args_headers)
+	{
+		cc = curl_easy_setopt(http_handle, CURLOPT_HTTPHEADER, curl_args_headers);
+		if (cc != CURLE_OK) I_OutputMsg("libcurl: %s\n", curl_errbuf);
+	}
+}

--- a/src/m_curl.h
+++ b/src/m_curl.h
@@ -1,0 +1,9 @@
+#ifndef __M_CURL__
+#define __M_CURL__
+
+#include <curl/curl.h>
+
+// Applies CLI args to curl handle, such as -curl-proxy
+void M_SetCURLArgs(CURL *http_handle, char *curl_errbuf);
+
+#endif


### PR DESCRIPTION
Adds -curl-proxy and -curl-header arguments, which can be used to customize how curl fetches list of servers from masterserver or downloads files from http repo's