### PR TITLE
Remove OpenGL adjusted "segs"

### DIFF
--- a/src/hardware/hw_bsp.c
+++ b/src/hardware/hw_bsp.c
@@ -80,14 +80,6 @@ static poly_t *HWR_AllocPoly(INT32 numpts)
 	return p;
 }
 
-static polyvertex_t *HWR_AllocVertex(void)
-{
-	polyvertex_t *p;
-	size_t size = sizeof(polyvertex_t);
-	p = Z_Malloc(size, PU_HWRPLANE, NULL);
-	return p;
-}
-
 /// \todo polygons should be freed in reverse order for efficiency,
 /// for now don't free because it doesn't free in reverse order
 static void HWR_FreePoly(poly_t *poly)
@@ -855,100 +847,6 @@ static INT32 SolveTProblem(void)
 	return numsplitpoly;
 }
 
-#define NEARDIST (0.75f)
-#define MYMAX    (10000000000000.0f)
-
-/* Adjust true segs (from the segs lump) to be exactely the same as
- * plane polygone segs
- * This also convert fixed_t point of segs in float (in moste case
- * it share the same vertice
- */
-static void AdjustSegs(void)
-{
-	size_t i, count;
-	INT32 j;
-	seg_t *lseg;
-	poly_t *p;
-	INT32 v1found = 0, v2found = 0;
-	float nearv1, nearv2;
-
-	for (i = 0; i < numsubsectors; i++)
-	{
-		count = subsectors[i].numlines;
-		lseg = &segs[subsectors[i].firstline];
-		p = extrasubsectors[i].planepoly;
-
-		if (!p)
-			continue;
-
-		for (; count--; lseg++)
-		{
-			float distv1,distv2,tmp;
-			nearv1 = nearv2 = MYMAX;
-
-			// Don't touch polyobject segs. We'll compensate
-			// for this when we go about drawing them.
-			if (lseg->polyseg)
-				continue;
-
-			for (j = 0; j < p->numpts; j++)
-			{
-				distv1 = p->pts[j].x - FIXED_TO_FLOAT(lseg->v1->x);
-				tmp    = p->pts[j].y - FIXED_TO_FLOAT(lseg->v1->y);
-				distv1 = distv1*distv1+tmp*tmp;
-
-				if (distv1 <= nearv1)
-				{
-					v1found = j;
-					nearv1 = distv1;
-				}
-
-				// the same with v2
-				distv2 = p->pts[j].x - FIXED_TO_FLOAT(lseg->v2->x);
-				tmp    = p->pts[j].y - FIXED_TO_FLOAT(lseg->v2->y);
-				distv2 = distv2*distv2+tmp*tmp;
-
-				if (distv2 <= nearv2)
-				{
-					v2found = j;
-					nearv2 = distv2;
-				}
-			}
-
-			if (nearv1 <= NEARDIST*NEARDIST)
-				// share vertice with segs
-				lseg->pv1 = &(p->pts[v1found]);
-			else
-			{
-				// BP: here we can do better, using PointInSeg and compute
-				// the right point position also split a polygone side to
-				// solve a T-intersection, but too mush work
-
-				// convert fixed vertex to float vertex
-				polyvertex_t *pv = HWR_AllocVertex();
-				pv->x = FIXED_TO_FLOAT(lseg->v1->x);
-				pv->y = FIXED_TO_FLOAT(lseg->v1->y);
-				lseg->pv1 = pv;
-			}
-
-			if (nearv2 <= NEARDIST*NEARDIST)
-				lseg->pv2 = &(p->pts[v2found]);
-			else
-			{
-				polyvertex_t *pv = HWR_AllocVertex();
-				pv->x = FIXED_TO_FLOAT(lseg->v2->x);
-				pv->y = FIXED_TO_FLOAT(lseg->v2->y);
-				lseg->pv2 = pv;
-			}
-
-			lseg->pv1->x2 = FloatToFixed(lseg->pv1->x);
-			lseg->pv1->y2 = FloatToFixed(lseg->pv1->y);
-			lseg->pv2->x2 = FloatToFixed(lseg->pv2->x);
-			lseg->pv2->y2 = FloatToFixed(lseg->pv2->y);
-		}
-	}
-}
-
 
 // call this routine after the BSP of a Doom wad file is loaded,
 // and it will generate all the convex polys for the hardware renderer
@@ -1017,7 +915,6 @@ void HWR_CreatePlanePolygons(INT32 bspnum)
 #else
 	SolveTProblem();
 #endif
-	AdjustSegs();
 
 #ifdef DEBUG_HWBSP
 	//debug debug..

--- a/src/hardware/hw_main.cpp
+++ b/src/hardware/hw_main.cpp
@@ -741,27 +741,11 @@ static void HWR_RenderPlane(subsector_t *subsector, extrasubsector_t *xsub, bool
 			P_ClosestPointOnLine(viewx, viewy, ld, &v);
 			dist = FixedToFloat(R_PointToDist(v.x, v.y));
 
-			if (line->pv1)
-			{
-				x1 = line->pv1->x;
-				y1 = line->pv1->y;
-			}
-			else
-			{
-				x1 = FixedToFloat(line->v1->x);
-				y1 = FixedToFloat(line->v1->y);
-			}
+			x1 = (line->fv1.x);
+			y1 = (line->fv1.y);
 
-			if (line->pv2)
-			{
-				xd = line->pv2->x - x1;
-				yd = line->pv2->y - y1;
-			}
-			else
-			{
-				xd = FixedToFloat(line->v2->x) - x1;
-				yd = FixedToFloat(line->v2->y) - y1;
-			}
+			xd = (line->fv2.x) - x1;
+			yd = (line->fv2.y) - y1;
 
 			// Based on the seg length and the distance from the line, split horizon into multiple poly sets to reduce distortion
 			dist = sqrtf((xd*xd) + (yd*yd)) / dist / 16.0f;
@@ -825,11 +809,11 @@ static void HWR_DrawSegsSplats(FSurfaceInfo * pSurf)
 
 	M_ClearBox(segbbox);
 	M_AddToBox(segbbox,
-		FloatToFixed(gl_curline->pv1->x),
-		FloatToFixed(gl_curline->pv1->y));
+		FloatToFixed(gl_curline->fv1.x),
+		FloatToFixed(gl_curline->fv1.y));
 	M_AddToBox(segbbox,
-		FloatToFixed(gl_curline->pv2->x),
-		FloatToFixed(gl_curline->pv2->y));
+		FloatToFixed(gl_curline->fv2.x),
+		FloatToFixed(gl_curline->fv2.y));
 
 	splat = (wallsplat_t *)gl_curline->linedef->splats;
 	for (; splat; splat = splat->next)
@@ -1324,35 +1308,15 @@ void HWR_ProcessSeg(void) // Sort of like GLWall::Process in GZDoom
 
 	const boolean noencore = (gl_linedef->flags & ML_TFERLINE);
 
-	if (LIKELY(gl_curline->pv1))
-	{
-		vs.x = gl_curline->pv1->x;
-		vs.y = gl_curline->pv1->y;
-		v1x = gl_curline->pv1->x2;
-		v1y = gl_curline->pv1->y2;
-	}
-	else
-	{
-		vs.x = FixedToFloat(gl_curline->v1->x);
-		vs.y = FixedToFloat(gl_curline->v1->y);
-		v1x = gl_curline->v1->x;
-		v1y = gl_curline->v1->y;
-	}
+	vs.x = (gl_curline->fv1.x);
+	vs.y = (gl_curline->fv1.y);
+	v1x = gl_curline->v1->x;
+	v1y = gl_curline->v1->y;
 
-	if (LIKELY(gl_curline->pv2))
-	{
-		ve.x = gl_curline->pv2->x;
-		ve.y = gl_curline->pv2->y;
-		v2x = gl_curline->pv2->x2;
-		v2y = gl_curline->pv2->y2;
-	}
-	else
-	{
-		ve.x = FixedToFloat(gl_curline->v2->x);
-		ve.y = FixedToFloat(gl_curline->v2->y);
-		v2x = gl_curline->v2->x;
-		v2y = gl_curline->v2->y;
-	}
+	ve.x = (gl_curline->fv2.x);
+	ve.y = (gl_curline->fv2.y);
+	v2x = gl_curline->v2->x;
+	v2y = gl_curline->v2->y;
 
 #define SLOPEPARAMS(slope, end1, end2, normalheight) \
 	end1 = P_GetZAt(slope, v1x, v1y, normalheight);  \
@@ -2203,27 +2167,11 @@ static boolean CheckClip(sector_t * afrontsector, sector_t * abacksector)
 	{
 		fixed_t v1x, v1y, v2x, v2y; // the seg's vertexes as fixed_t
 
-		if (LIKELY(gl_curline->pv1))
-		{
-			v1x = gl_curline->pv1->x2;
-			v1y = gl_curline->pv1->y2;
-		}
-		else
-		{
-			v1x = gl_curline->v1->x;
-			v1y = gl_curline->v1->y;
-		}
+		v1x = gl_curline->v1->x;
+		v1y = gl_curline->v1->y;
 
-		if (LIKELY(gl_curline->pv2))
-		{
-			v2x = gl_curline->pv2->x2;
-			v2y = gl_curline->pv2->y2;
-		}
-		else
-		{
-			v2x = gl_curline->v2->x;
-			v2y = gl_curline->v2->y;
-		}
+		v2x = gl_curline->v2->x;
+		v2y = gl_curline->v2->y;
 
 #define SLOPEPARAMS(slope, end1, end2, normalheight) \
 		end1 = P_GetZAt(slope, v1x, v1y, normalheight); \
@@ -2428,27 +2376,11 @@ static void HWR_AddLine(seg_t *line)
 
 	gl_curline = line;
 
-	if (LIKELY(gl_curline->pv1))
-	{
-		v1x = gl_curline->pv1->x2;
-		v1y = gl_curline->pv1->y2;
-	}
-	else
-	{
-		v1x = gl_curline->v1->x;
-		v1y = gl_curline->v1->y;
-	}
+	v1x = gl_curline->v1->x;
+	v1y = gl_curline->v1->y;
 
-	if (LIKELY(gl_curline->pv2))
-	{
-		v2x = gl_curline->pv2->x2;
-		v2y = gl_curline->pv2->y2;
-	}
-	else
-	{
-		v2x = gl_curline->v2->x;
-		v2y = gl_curline->v2->y;
-	}
+	v2x = gl_curline->v2->x;
+	v2y = gl_curline->v2->y;
 
 	// OPTIMIZE: quickly reject orthogonal back sides.
 	angle1 = R_PointToAngle64(v1x, v1y);

--- a/src/hardware/hw_main.cpp
+++ b/src/hardware/hw_main.cpp
@@ -729,6 +729,9 @@ static void HWR_RenderPlane(subsector_t *subsector, extrasubsector_t *xsub, bool
 
 		for (i = 0; i < subsector->numlines; i++, line++)
 		{
+			if (line->polyseg)
+				continue;
+
 			line_t* ld = line->linedef;
 
 			// this check sucks and is a hotspot lel
@@ -1308,15 +1311,25 @@ void HWR_ProcessSeg(void) // Sort of like GLWall::Process in GZDoom
 
 	const boolean noencore = (gl_linedef->flags & ML_TFERLINE);
 
-	vs.x = (gl_curline->fv1.x);
-	vs.y = (gl_curline->fv1.y);
 	v1x = gl_curline->v1->x;
 	v1y = gl_curline->v1->y;
-
-	ve.x = (gl_curline->fv2.x);
-	ve.y = (gl_curline->fv2.y);
 	v2x = gl_curline->v2->x;
 	v2y = gl_curline->v2->y;
+
+	if (gl_curline->polyseg)
+	{
+		vs.x = FixedToFloat(v1x);
+		vs.y = FixedToFloat(v1y);
+		ve.x = FixedToFloat(v2x);
+		ve.y = FixedToFloat(v2y);
+	}
+	else
+	{
+		vs.x = gl_curline->fv1.x;
+		vs.y = gl_curline->fv1.y;
+		ve.x = gl_curline->fv2.x;
+		ve.y = gl_curline->fv2.y;
+	}
 
 #define SLOPEPARAMS(slope, end1, end2, normalheight) \
 	end1 = P_GetZAt(slope, v1x, v1y, normalheight);  \

--- a/src/p_setup.c
+++ b/src/p_setup.c
@@ -544,7 +544,18 @@ static void P_LoadSegs(UINT8 *data)
 	{
 		li->v1 = &vertexes[SHORT(ml->v1)];
 		li->v2 = &vertexes[SHORT(ml->v2)];
+#ifdef HWRENDER
+		if (rendermode == render_opengl)
+		{
+			li->fv1.x = FixedToFloat(li->v1->x);
+			li->fv1.y = FixedToFloat(li->v1->y);
+			//li->fv1.z = FixedToFloat(li->v1->z); // z is unused in gl
 
+			li->fv2.x = FixedToFloat(li->v2->x);
+			li->fv2.y = FixedToFloat(li->v2->y);
+			//li->fv2.z = FixedToFloat(li->v2->z);
+		}
+#endif
 		li->length = P_SegLength(li);
 		li->angle = (SHORT(ml->angle))<<FRACBITS;
 		li->offset = (SHORT(ml->offset))<<FRACBITS;

--- a/src/r_defs.h
+++ b/src/r_defs.h
@@ -114,6 +114,11 @@ typedef struct
 	fixed_t x, y, z;
 } vertex_t;
 
+typedef struct
+{
+	float x, y/*, z*/;
+} floatvertex_t;
+
 // Forward of linedefs, for sectors.
 struct line_s;
 
@@ -543,12 +548,11 @@ typedef struct seg_s
 	sector_t *frontsector;
 	sector_t *backsector;
 
-	fixed_t length;	// precalculated seg length
+	fixed_t length; // precalculated seg length
 
 #ifdef HWRENDER
-	// new pointers so that AdjustSegs doesn't mess with v1/v2
-	polyvertex_t *pv1;
-	polyvertex_t *pv2;
+	floatvertex_t fv1;
+	floatvertex_t fv2;
 #endif
 
 	polyobj_t *polyseg;


### PR DESCRIPTION
This removes the opengl specific seg adjustment
We dont use polyvertex´s anymore but instead just convert seg vertex coordinates to float at map start
Only special case are polyobjects, they need to be handled in their own way
This should speed up levelload and runtime performance a bit and slightly reduce memory usage aswell
So far i couldnt see any visual differences or regressions, but definitely needs further testing

The orginal purpose of those were:
The gl renderer precalculates plane polygons at levelstart, while trying to fix holes and map issues
Since those may differ slightly from the "original" planes, the "segs" were to be adjusted to fit them