### PR TITLE
CMake fixes cherry-picked from srb2-legacy

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,28 @@ if(${PROJECT_SOURCE_DIR} MATCHES ${PROJECT_BINARY_DIR})
 	message(FATAL_ERROR "In-source builds will bring you a world of pain. Please make a separate directory to invoke CMake from.")
 endif()
 
+##### PACKAGE CONFIGURATION #####
+
+if(${CMAKE_SYSTEM} MATCHES "Windows")
+	set(CPACK_GENERATOR "ZIP")
+endif()
+if(${CMAKE_SYSTEM} MATCHES "Linux")
+	set(CPACK_GENERATOR "TGZ")
+endif()
+if(${CMAKE_SYSTEM} MATCHES "Darwin")
+	set(CPACK_GENERATOR "DragNDrop")
+endif()
+
+set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "Sonic Robo Blast 2 Kart" CACHE STRING "Program name for display purposes")
+set(CPACK_PACKAGE_VENDOR "Kart Krew" CACHE STRING "Vendor name for display purposes")
+#set(CPACK_PACKAGE_DESCRIPTION_FILE )
+set(CPACK_RESOURCE_FILE_LICENSE "${CMAKE_CURRENT_SOURCE_DIR}/LICENSE")
+set(CPACK_PACKAGE_VERSION_MAJOR ${SRB2_VERSION_MAJOR})
+set(CPACK_PACKAGE_VERSION_MINOR ${SRB2_VERSION_MINOR})
+set(CPACK_PACKAGE_VERSION_PATCH ${SRB2_VERSION_PATCH})
+set(CPACK_PACKAGE_INSTALL_DIRECTORY "CMake ${CMAKE_VERSION_MAJOR}.${CMAKE_VERSION_MINOR}")
+include(CPack)
+
 # Set up CMAKE path
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake/Modules/")
 
@@ -100,15 +122,10 @@ endif()
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin")
 set(CMAKE_PDB_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin")
 
-# Set EXE names so the assets CMakeLists can refer to its target
-set(SRB2_SDL2_EXE_NAME srb2kart CACHE STRING "Executable binary output name")
-set(SRB2_WIN_EXE_NAME srb2kartdd CACHE STRING "Executable binary output name for DirectDraw build")
-
 include_directories(${CMAKE_CURRENT_BINARY_DIR}/src)
 
 add_subdirectory(src)
 add_subdirectory(assets)
-
 
 ## config.h generation
 set(GIT_EXECUTABLE "git" CACHE FILEPATH "Path to git binary")
@@ -118,25 +135,3 @@ git_current_branch(SRB2_GIT_BRANCH "${CMAKE_SOURCE_DIR}")
 set(SRB2_COMP_BRANCH "${SRB2_GIT_BRANCH}")
 set(SRB2_COMP_REVISION "${SRB2_COMP_COMMIT}")
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/src/config.h.in ${CMAKE_CURRENT_BINARY_DIR}/src/config.h)
-
-##### PACKAGE CONFIGURATION #####
-
-if(${CMAKE_SYSTEM} MATCHES "Windows")
-	set(CPACK_GENERATOR "ZIP")
-endif()
-if(${CMAKE_SYSTEM} MATCHES "Linux")
-	set(CPACK_GENERATOR "TGZ")
-endif()
-if(${CMAKE_SYSTEM} MATCHES "Darwin")
-	set(CPACK_GENERATOR "DragNDrop")
-endif()
-
-set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "Sonic Robo Blast 2 Kart" CACHE STRING "Program name for display purposes")
-set(CPACK_PACKAGE_VENDOR "Kart Krew" CACHE STRING "Vendor name for display purposes")
-#set(CPACK_PACKAGE_DESCRIPTION_FILE )
-set(CPACK_RESOURCE_FILE_LICENSE "${CMAKE_CURRENT_SOURCE_DIR}/LICENSE")
-set(CPACK_PACKAGE_VERSION_MAJOR ${SRB2_VERSION_MAJOR})
-set(CPACK_PACKAGE_VERSION_MINOR ${SRB2_VERSION_MINOR})
-set(CPACK_PACKAGE_VERSION_PATCH ${SRB2_VERSION_PATCH})
-set(CPACK_PACKAGE_INSTALL_DIRECTORY "CMake ${CMAKE_VERSION_MAJOR}.${CMAKE_VERSION_MINOR}")
-include(CPack)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,9 @@
 cmake_minimum_required(VERSION 3.5)
+
+if(${PROJECT_SOURCE_DIR} MATCHES ${PROJECT_BINARY_DIR})
+	message(FATAL_ERROR "In-source builds will bring you a world of pain. Please make a separate directory to invoke CMake from.")
+endif()
+
 # DO NOT CHANGE THIS SRB2 STRING! Some variable names depend on this string.
 # Version change is fine.
 project(SRB2
@@ -11,22 +16,21 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS ON)
 set(CMAKE_C_EXTENSIONS ON)
 
-if(${PROJECT_SOURCE_DIR} MATCHES ${PROJECT_BINARY_DIR})
-	message(FATAL_ERROR "In-source builds will bring you a world of pain. Please make a separate directory to invoke CMake from.")
-endif()
-
 ##### PACKAGE CONFIGURATION #####
 
-if(${CMAKE_SYSTEM} MATCHES "Windows")
-	set(CPACK_GENERATOR "ZIP")
-endif()
-if(${CMAKE_SYSTEM} MATCHES "Linux")
-	set(CPACK_GENERATOR "TGZ")
-endif()
-if(${CMAKE_SYSTEM} MATCHES "Darwin")
-	set(CPACK_GENERATOR "DragNDrop")
+set(SRB2_CPACK_GENERATOR "" CACHE STRING "Generator to use for making a package. E.g., ZIP, TGZ, DragNDrop (OSX only). Leave blank for default generator.")
+
+if("${SRB2_CPACK_GENERATOR}" STREQUAL "")
+	if("${CMAKE_SYSTEM_NAME}" MATCHES "Windows")
+		set(SRB2_CPACK_GENERATOR "ZIP")
+	elseif("${CMAKE_SYSTEM_NAME}" MATCHES "Linux")
+		set(SRB2_CPACK_GENERATOR "TGZ")
+	elseif("${CMAKE_SYSTEM_NAME}" MATCHES "Darwin")
+		set(SRB2_CPACK_GENERATOR "TGZ")
+	endif()
 endif()
 
+set(CPACK_GENERATOR ${SRB2_CPACK_GENERATOR})
 set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "Sonic Robo Blast 2 Kart" CACHE STRING "Program name for display purposes")
 set(CPACK_PACKAGE_VENDOR "Kart Krew" CACHE STRING "Vendor name for display purposes")
 #set(CPACK_PACKAGE_DESCRIPTION_FILE )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -126,6 +126,9 @@ endif()
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin")
 set(CMAKE_PDB_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin")
 
+# Set EXE names so the assets CMakeLists can refer to its target
+set(SRB2_SDL2_EXE_NAME srb2kart CACHE STRING "Executable binary output name")
+
 include_directories(${CMAKE_CURRENT_BINARY_DIR}/src)
 
 add_subdirectory(src)

--- a/cmake/Modules/FindGME.cmake
+++ b/cmake/Modules/FindGME.cmake
@@ -8,6 +8,7 @@ find_path(GME_INCLUDE_DIR
 		${GME_PKGCONF_INCLUDE_DIRS}
 		"/usr/include/gme"
 		"/usr/local/include/gme"
+	PATH_SUFFIXES gme
 )
 
 find_library(GME_LIBRARY

--- a/cmake/Modules/FindGME.cmake
+++ b/cmake/Modules/FindGME.cmake
@@ -1,6 +1,6 @@
 include(LibFindMacros)
 
-libfind_pkg_check_modules(GME_PKGCONF GME)
+libfind_pkg_check_modules(GME_PKGCONF LIBGME)
 
 find_path(GME_INCLUDE_DIR
 	NAMES gme.h

--- a/cmake/Modules/FindOPENMPT.cmake
+++ b/cmake/Modules/FindOPENMPT.cmake
@@ -1,6 +1,6 @@
 include(LibFindMacros)
 
-libfind_pkg_check_modules(OPENMPT_PKGCONF OPENMPT)
+libfind_pkg_check_modules(OPENMPT_PKGCONF LIBOPENMPT)
 
 find_path(OPENMPT_INCLUDE_DIR
 	NAMES libopenmpt.h
@@ -8,6 +8,7 @@ find_path(OPENMPT_INCLUDE_DIR
 		${OPENMPT_PKGCONF_INCLUDE_DIRS}
 		"/usr/include/libopenmpt"
 		"/usr/local/include/libopenmpt"
+	PATH_SUFFIXES libopenmpt
 )
 
 find_library(OPENMPT_LIBRARY


### PR DESCRIPTION
- Sets the name of the application name before configuring, so it doesn't use the default `SRB2SDL2` for the app bundle name 
     - Hopefully I never have to see `SRB2SDL2.app` printed ever again
- Fixes discovery of libopenmpt and libgme
- Updates `LibFindMacros.cmake` (Includes https://github.com/P-AS/srb2-legacy/commit/d1c6e09578dac37fcfb81d4574d24a6d9e732229)